### PR TITLE
Hash after dupe found

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -4,4 +4,5 @@ filter=-build/include_subdir
 filter=-build/header_guard
 filter=-build/c++14
 filter=-build/c++17
+filter=-build/include_what_you_use
 filter=-runtime/threadsafe_fn

--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -22,6 +22,16 @@ class FileInfo{
             _FileSize(FileSize),
             _Hash(DEAD_HASH),
             _DateFound(DateFound) {}
+    FileInfo(const fs::path& FilePath,
+             const QString& FileType,
+             const uintmax_t FileSize,
+             const QByteArray& Hash,
+             const QDateTime& DateFound):
+        _FilePath(FilePath),
+        _FileType(FileType),
+        _FileSize(FileSize),
+        _Hash(Hash),
+        _DateFound(DateFound) {}
     const fs::path& getFilePath() const { return _FilePath; }
     QByteArray getHash() { return _Hash; }
     const QDateTime& getDate() const { return _DateFound; }

--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -1,10 +1,13 @@
 // Copyright 2025 Replica Reaper
+#pragma once
 #ifndef FILEINFO_HPP
 #define FILEINFO_HPP
 #include <QString>
 #include <QDateTime>
 #include <cstdint>
 #include <filesystem>
+
+inline const QByteArray DEAD_HASH = QByteArray::fromHex("0000000000000000");
 
 namespace fs = std::filesystem;
 
@@ -13,18 +16,19 @@ class FileInfo{
     FileInfo(const fs::path& FilePath,
              const QString& FileType,
              const uintmax_t FileSize,
-             const QByteArray& Hash,
              const QDateTime& DateFound):
             _FilePath(FilePath),
             _FileType(FileType),
             _FileSize(FileSize),
-            _Hash(Hash),
+            _Hash(DEAD_HASH),
             _DateFound(DateFound) {}
     const fs::path& getFilePath() const { return _FilePath; }
-    const QByteArray& getHash() const { return _Hash; }
+    QByteArray getHash() { return _Hash; }
     const QDateTime& getDate() const { return _DateFound; }
     const QString& getFileType() const { return _FileType; }
     const uintmax_t& getFileSize() const { return _FileSize; }
+
+    void setHash(const QByteArray& h) { _Hash = h; }
 
  private:
     fs::path _FilePath;

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -38,8 +38,7 @@ class FileManagerTest : public QObject {
   void myFirstTest();   // sample test with conditionals
   void mySecondTest();  // another sample
 
-  void
-  testListFilesFail();  // test invalid directory returns empty QStringList()
+  void testListFilesFail();  // test invalid directory returns empty QStringList()
   void testAddFileToList();
 
   // cleanupTestCase() will be called after the last test function was executed.

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -7,9 +7,16 @@
 #include <QObject>
 #include <QSystemTrayIcon>
 #include <QMainWindow>
+#include <QFileDialog>
+#include <QCryptographicHash>
+#include <QFile>
+#include <QApplication>
+#include <QStyle>
+#include <QMenu>
 #include <unordered_map>
 #include <iostream>
 #include <list>
+#include <string>
 #include "FileInfo.hpp"
 
 using std::unordered_map;
@@ -24,8 +31,8 @@ class FileManager : public QObject {
     QStringList ListFiles(const QString& directoryPath);
     void AddToDupes(const FileInfo& File);
     void ShowNotification(const QString& title, const QString& message);
-    void addFileToList(const FileInfo& file);
-    void CheckAndAddDupes(const std::list<FileInfo>& list, const FileInfo& file);
+    void addFileToList(FileInfo& file);
+    void CheckAndAddDupes(std::list<FileInfo>& list, FileInfo& file);
     void setMainWindow(QMainWindow *ui);
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     ~FileManager();

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 // Copyright 2025 Replica Reaper
-#include <QApplication>
 #include "mainwindow.hpp"
 
 int main(int argc, char *argv[]) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,15 +1,6 @@
 // Copyright 2025 Replica Reaper
-#include <QCloseEvent>
-#include <QString>
-#include <QListWidget>
-#include <QDateTime>
-#include <filesystem>
-#include <iostream>
-#include <string>
-#include "FileInfo.hpp"
 #include "mainwindow.hpp"
 #include "./ui_mainwindow.h"
-#include "filemanager.hpp"
 
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent), ui(new Ui::MainWindow), manager(new FileManager()) {
@@ -55,20 +46,17 @@ void MainWindow::onPushButtonClicked() {
   // Set a timer for hashing all files
   QElapsedTimer timer;
   timer.start();
+
   // Loop through each file and hash it (prints to console for now)
   for (int i = 0; i < filePaths.size(); ++i) {
     // setup for FileInfo class
-    // QString file = filePaths[i];
-    QByteArray hash = manager->HashFile(filePaths[i]);
     fs::path fPath = filePaths[i].toStdString();
     QDateTime currentDateTime = QDateTime::currentDateTime();
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
-                  fs::file_size(fPath), hash, currentDateTime);
+                  fs::file_size(fPath), currentDateTime);
     // Push and sort FileInfo class into FileManager class
     manager->addFileToList(file);
-    std::cout << *manager;  // DEBUG *************
-
-    qDebug() << "File: " << filePaths[i] << "\nHash: " << hash;
+    // std::cout << *manager;  // DEBUG *************
 
     // Update progress bar
     ui->progressBar->setValue(i + 1);
@@ -76,6 +64,9 @@ void MainWindow::onPushButtonClicked() {
     // Process events to keep UI responsive (for progress bar)
     QCoreApplication::processEvents();
   }
+
+  // std::cout << *manager;  // DEBUG *************
+
   // returns elapsed time in milliseconds ( /1000 for seconds)
   auto elapsedTime = timer.elapsed();
   QString message =
@@ -102,21 +93,12 @@ void MainWindow::ShowDupesInUI(const FileManager& f) {
         } else {
           std::cout << "am i in case 2********\n";
           QString out = QString::fromStdString(file.getFilePath().string());
-          // std::cout << file.getFilePathFuckQstring();
           out.append("     ");
           ui->listWidget->addItem(out);
         }
       }
     }
   }
-  /*
 
-
-      QDateTime currentDateTime = QDateTime::currentDateTime();
-      QString ItemToAdd = FilePath;
-      ItemToAdd.append("     ");
-      ItemToAdd.append(currentDateTime.toString());
-      ui->listWidget->addItem(ItemToAdd);
-  */
   return;
 }

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -4,7 +4,16 @@
 #define MAINWINDOW_HPP
 
 #include <QMainWindow>
+#include <QCloseEvent>
+#include <QString>
+#include <QListWidget>
+#include <QDateTime>
+#include <QApplication>
+#include <filesystem>
+#include <iostream>
+#include <string>
 #include "filemanager.hpp"
+#include "FileInfo.hpp"
 
 QT_BEGIN_NAMESPACE
 namespace Ui {


### PR DESCRIPTION
This PR hashes files only once they are added to the list of same type and size. This reduces time significantly

It adds files that have been verified to be duplicates by hash to the "Dupes" std::unordered_map

It also adds a constructor to the FileInfo class to create an object with or without a hash

Moves includes to their corresponding header files

Also updates the cpplint config file to ignore "build/include_what_you_use" since includes were moved to their header files