### PR TITLE
Hash Verification of Duplicates

### DIFF
--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -40,6 +40,8 @@ class FileInfo{
 
     void setHash(const QByteArray& h) { _Hash = h; }
 
+    friend bool operator<(const FileInfo& a, const FileInfo& b) { return a._Hash < b._Hash; }
+    friend bool operator==(const FileInfo& a, const FileInfo& b) { return a._Hash == b._Hash; }
  private:
     fs::path _FilePath;
     QString _FileType;
@@ -47,5 +49,7 @@ class FileInfo{
     QByteArray _Hash;
     QDateTime _DateFound;
 };
+
+
 
 #endif /* FILEINFO_HPP */

--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -42,6 +42,7 @@ class FileInfo{
 
     friend bool operator<(const FileInfo& a, const FileInfo& b) { return a._Hash < b._Hash; }
     friend bool operator==(const FileInfo& a, const FileInfo& b) { return a._Hash == b._Hash; }
+
  private:
     fs::path _FilePath;
     QString _FileType;

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -68,13 +68,13 @@ QStringList FileManager::ListFiles(const QString& directoryPath) {
     fullPaths.append(it.next());
   }
 
-  //qDebug() << "Files in directory (recursive):" << fullPaths;
+  // qDebug() << "Files in directory (recursive):" << fullPaths;
   return fullPaths;
 }
 
 void FileManager::addFileToList(FileInfo& file) {
-  auto& sizeMap = AllFilesByTypeSize[file.getFileType()]; // list of same size file types
-  auto& fileList = sizeMap[file.getFileSize()]; // list of same-sized file infos
+  auto& sizeMap = AllFilesByTypeSize[file.getFileType()];  // list of same size file types
+  auto& fileList = sizeMap[file.getFileSize()];  // list of same-sized file infos
 
   fileList.push_back(file);
 
@@ -93,32 +93,32 @@ void FileManager::CheckAndAddDupes(std::list<FileInfo>& list, FileInfo& file) {
 
     // List to hold duplicates
     std::list<QByteArray> HashList;
-    //find and store all unique hashes
+    // find and store all unique hashes
     for (auto& fileInfo : list) {
         QByteArray currentHash = fileInfo.getHash();
-        //is hash already in hashList?
+        // is hash already in hashList?
         auto it = std::find(HashList.begin(), HashList.end(), currentHash);
         if (it == HashList.end()) {
             HashList.push_back(currentHash);
-            //qDebug() << currentHash;
+            // qDebug() << currentHash;
         }
     }
 
-    //runs through the list and pushes all elements of list
-    //matching hash to dlist. If dlist is > 1 then it is pushed
-    //to dupe
-    for(auto& a : HashList){
+    // runs through the list and pushes all elements of list
+    // matching hash to dlist. If dlist is > 1 then it is pushed
+    // to dupe
+    for (auto& a : HashList) {
         std::list<FileInfo> dList;
-        for(auto& b : list){
-            if(a == b.getHash()){
+        for (auto& b : list) {
+            if (a == b.getHash()) {
                 dList.push_back(b);
             }
         }
-        if(dList.size() > 1){
+
+        if (dList.size() > 1) {
             Dupes[dList.begin()->getHash()] = {dList};
         }
     }
-
 }
 
 std::ostream& operator<<(std::ostream& out, const FileManager& f) {

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -2,7 +2,6 @@
 #include "filemanager.hpp"
 #include "mainwindow.hpp"
 
-
 FileManager::FileManager(QObject* parent)
     : QObject(parent), trayIcon(new QSystemTrayIcon()), ui(nullptr) {
   // can also set our custon icon like this:
@@ -55,22 +54,22 @@ QByteArray FileManager::HashFile(QString fileName) {
 }
 
 QStringList FileManager::ListFiles(const QString& directoryPath) {
-    QDir dir(directoryPath);
-    if (!dir.exists()) {
-        qWarning() << "Directory does not exist:" << directoryPath;
-        return QStringList();
-    }
+  QDir dir(directoryPath);
+  if (!dir.exists()) {
+    qWarning() << "Directory does not exist:" << directoryPath;
+    return QStringList();
+  }
 
-    QStringList fullPaths;
-    QDirIterator it(directoryPath, QDir::Files | QDir::NoDotAndDotDot,
-                    QDirIterator::Subdirectories);
+  QStringList fullPaths;
+  QDirIterator it(directoryPath, QDir::Files | QDir::NoDotAndDotDot,
+                  QDirIterator::Subdirectories);
 
-    while (it.hasNext()) {
-        fullPaths.append(it.next());
-    }
+  while (it.hasNext()) {
+    fullPaths.append(it.next());
+  }
 
-    qDebug() << "Files in directory (recursive):" << fullPaths;
-    return fullPaths;
+  qDebug() << "Files in directory (recursive):" << fullPaths;
+  return fullPaths;
 }
 
 void FileManager::addFileToList(FileInfo& file) {
@@ -83,28 +82,27 @@ void FileManager::addFileToList(FileInfo& file) {
   if (fileList.size() > 1) CheckAndAddDupes(fileList, file);
 }
 
-void FileManager::CheckAndAddDupes(std::list<FileInfo>& list,
-                                   FileInfo& file) {
-    // make sure each file in list has a hash
-    for (auto& f : list) {
-        if (f.getHash() == DEAD_HASH)
-            f.setHash(HashFile(QString::fromStdString((f.getFilePath().string()))));
-    }
+void FileManager::CheckAndAddDupes(std::list<FileInfo>& list, FileInfo& file) {
+  // make sure each file in list has a hash
+  for (auto& f : list) {
+    if (f.getHash() == DEAD_HASH)
+      f.setHash(HashFile(QString::fromStdString((f.getFilePath().string()))));
+  }
 
-    // hash file
-    file.setHash(HashFile(QString::fromStdString((file.getFilePath().string()))));
-    std::list<FileInfo> dList = {file};
-    // check hashes and confirm filepaths not same
-    for (auto& f : list) {
-        if (f.getHash() == file.getHash()) {
-            // add to dupes
-            dList.push_back(f);
-            qDebug() << "Hash verified." << file.getFilePath().string()
-                     << "HASH: " << file.getHash();
-        }
+  // hash file
+  file.setHash(HashFile(QString::fromStdString((file.getFilePath().string()))));
+  std::list<FileInfo> dList = {file};
+  // check hashes and confirm filepaths not same
+  for (auto& f : list) {
+    if (f.getHash() == file.getHash()) {
+      // add to dupes
+      dList.push_back(f);
+      qDebug() << "Hash verified." << file.getFilePath().string()
+               << "HASH: " << file.getHash();
     }
-    Dupes[file.getHash()] = dList;
-    return;
+  }
+  Dupes[file.getHash()] = dList;
+  return;
 }
 
 std::ostream& operator<<(std::ostream& out, const FileManager& f) {

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -34,9 +34,12 @@ class FileManager : public QObject {
     void AddToDupes(const FileInfo& File);
     void ShowNotification(const QString& title, const QString& message);
     void addFileToList(FileInfo& file);
-    void CheckAndAddDupes(std::list<FileInfo>& list, FileInfo& file);
+    void CheckAndAddDupes(std::list<FileInfo>& list);
     void setMainWindow(QMainWindow *ui);
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+    std::list<QByteArray> StoreUniqueHashes(std::list<FileInfo>& list);
+    void AddDupesToMap(std::list<FileInfo>& list, const std::list<QByteArray>& HashList);
+    void UpdateHashes(std::list<FileInfo>& list);
     ~FileManager();
 
     friend std::ostream& operator<<(std::ostream& out,

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <list>
 #include <string>
+#include <algorithm>
 #include "FileInfo.hpp"
 
 using std::unordered_map;

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -42,6 +42,7 @@ class FileManager : public QObject {
                 const FileManager& f);
 
     unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>> AllFilesByTypeSize;
+    unordered_map<QByteArray, std::list<FileInfo>> Dupes;
 
  private:
     QSystemTrayIcon* trayIcon;
@@ -52,7 +53,6 @@ class FileManager : public QObject {
     // unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>> AllFilesByTypeSize;
     // Holds list of list of duplicates
     // no particular order
-    unordered_map<QByteArray, std::list<FileInfo>> Dupes;
 };
 
 #endif /* FILEMANAGER_HPP */

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -55,7 +55,7 @@ void MainWindow::onPushButtonClicked() {
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                   fs::file_size(fPath), currentDateTime);
     // Push and sort FileInfo class into FileManager class
-    manager->addFileToList(file);
+    manager->addFileToList(file); // passes in fileinfo
     // std::cout << *manager;  // DEBUG *************
 
     // Update progress bar

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -55,7 +55,7 @@ void MainWindow::onPushButtonClicked() {
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                   fs::file_size(fPath), currentDateTime);
     // Push and sort FileInfo class into FileManager class
-    manager->addFileToList(file); // passes in fileinfo
+    manager->addFileToList(file);  // passes in fileinfo
     // std::cout << *manager;  // DEBUG *************
 
     // Update progress bar

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -82,23 +82,12 @@ void MainWindow::onPushButtonClicked() {
 // Does not currently locate items adjacently
 // NEED TO REFACTOR SO IT TAKES A FILEINFO
 void MainWindow::ShowDupesInUI(const FileManager& f) {
-  for (const auto& [fileType, MapSize] : f.AllFilesByTypeSize) {
-    // out << "File Type: " << fileType.toStdString() << "\n";
-    for (const auto& [fileSize, fileList] : MapSize) {
-      // out << "  Size: " << fileSize << " bytes\n";
-      for (const auto& file : fileList) {
-        if (fileList.size() <= 1) {
-          std::cout << "am i in case 1********\n";
-          continue;  // throw exception?
-        } else {
-          std::cout << "am i in case 2********\n";
-          QString out = QString::fromStdString(file.getFilePath().string());
-          out.append("     ");
-          ui->listWidget->addItem(out);
-        }
-      }
+  QString out;
+  for (auto it = f.Dupes.begin(); it != f.Dupes.end(); ++it) {
+    for (auto& a : it->second) {
+      out = QString::fromStdString(a.getFilePath().string());
+      out.append("     ");
+      ui->listWidget->addItem(out);
     }
   }
-
-  return;
 }


### PR DESCRIPTION
This branch was pair programmed by @isaiah-andrade @bradenmaillet and @ChrisLambert03 to repair CheckAndAddDupes to add hash verified duplicates to an Dupes map organized by hash. Also prints dupes from hash verified Dupes map.