### PR TITLE
Invalid Directory Crash Fix

### DIFF
--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -29,6 +29,12 @@ QString FileManager::PromptDirectory(QWidget* parent) {
   QString filePath = QFileDialog::getExistingDirectory(
       parent, "Open a Directory", QDir::homePath(),
       QFileDialog::DontResolveSymlinks);
+
+    if (filePath.isEmpty()) {
+      qDebug() << "No directory selected";
+        return QString();
+    }
+
   qDebug() << "Selected File Path: " << filePath;
   return filePath;
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -36,6 +36,11 @@ void MainWindow::onPushButtonClicked() {
   qDebug() << "Button clicked!";
 
   QString path = manager->PromptDirectory(this);
+  if (path == QString()) {
+      qDebug("Please select a directory");
+      return;
+  }
+
   QStringList filePaths = manager->ListFiles(path);
 
   // Set up the progress bar


### PR DESCRIPTION
This commit prevents the program from crashing if a directory is not selected. attempt to address bug #32 