### PR TITLE
File date implementation

### DIFF
--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -6,35 +6,35 @@
 #include <QDateTime>
 #include <cstdint>
 #include <filesystem>
+#include <QFileInfo>
+#include <iostream>
 
 inline const QByteArray DEAD_HASH = QByteArray::fromHex("0000000000000000");
 
 namespace fs = std::filesystem;
 
-class FileInfo{
+class FileInfo {
  public:
     FileInfo(const fs::path& FilePath,
              const QString& FileType,
-             const uintmax_t FileSize,
-             const QDateTime& DateFound):
+             const uintmax_t FileSize):
             _FilePath(FilePath),
             _FileType(FileType),
             _FileSize(FileSize),
             _Hash(DEAD_HASH),
-            _DateFound(DateFound) {}
+            _DateCreated(getFileCreationDate(FilePath)) {}
     FileInfo(const fs::path& FilePath,
              const QString& FileType,
              const uintmax_t FileSize,
-             const QByteArray& Hash,
-             const QDateTime& DateFound):
+             const QByteArray& Hash):
         _FilePath(FilePath),
         _FileType(FileType),
         _FileSize(FileSize),
         _Hash(Hash),
-        _DateFound(DateFound) {}
+        _DateCreated(getFileCreationDate(FilePath)) {}
     const fs::path& getFilePath() const { return _FilePath; }
     QByteArray getHash() { return _Hash; }
-    const QDateTime& getDate() const { return _DateFound; }
+    const QDateTime& getDate() const { return _DateCreated; }
     const QString& getFileType() const { return _FileType; }
     const uintmax_t& getFileSize() const { return _FileSize; }
 
@@ -48,9 +48,12 @@ class FileInfo{
     QString _FileType;
     uintmax_t _FileSize;
     QByteArray _Hash;
-    QDateTime _DateFound;
+    QDateTime _DateCreated;
+
+    static QDateTime getFileCreationDate(const fs::path& filePath) {
+        QFileInfo fileInfo(QString::fromStdString(filePath.string()));
+        return fileInfo.birthTime();
+    }
 };
-
-
 
 #endif /* FILEINFO_HPP */

--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -4,9 +4,9 @@
 #define FILEINFO_HPP
 #include <QString>
 #include <QDateTime>
-#include <cstdint>
-#include <filesystem>
 #include <QFileInfo>
+#include <filesystem>
+#include <cstdint>
 #include <iostream>
 
 inline const QByteArray DEAD_HASH = QByteArray::fromHex("0000000000000000");

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -57,6 +57,7 @@ class FileManagerTest : public QObject {
   void testFileInfoGetters();
   void testFileInfoSetHash();
   void testFileInfoComparisonOperators();
+  void testFileInfoDateCreated();
 
   // cleanupTestCase() will be called after the last test function was executed.
   void cleanupTestCase();
@@ -175,20 +176,17 @@ void FileManagerTest::testAddFileToList() {
   fs::path fPath = fs::current_path() / "TestFiles/testfile1.txt";
   FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                 fs::file_size(fPath),
-                testManager.HashFile("TestFiles/testfile1.txt"),
-                QDateTime::currentDateTime());
+                testManager.HashFile("TestFiles/testfile1.txt"));
 
   fs::path fPathDupe = fs::current_path() / "TestFiles/testfile3.txt";
   FileInfo fileDupe(
       fPathDupe, QString::fromStdString(fPathDupe.extension().string()),
-      fs::file_size(fPathDupe), testManager.HashFile("TestFiles/testfile3.txt"),
-      QDateTime::currentDateTime());
+      fs::file_size(fPathDupe), testManager.HashFile("TestFiles/testfile3.txt"));
 
   fs::path fPathDiff = fs::current_path() / "TestFiles/testfile2.txt";
   FileInfo fileDiff(
       fPathDiff, QString::fromStdString(fPathDiff.extension().string()),
-      fs::file_size(fPathDiff), testManager.HashFile("TestFiles/testfile2.txt"),
-      QDateTime::currentDateTime());
+      fs::file_size(fPathDiff), testManager.HashFile("TestFiles/testfile2.txt"));
 
   // add test file to list
   testManager.addFileToList(file);
@@ -248,56 +246,49 @@ void FileManagerTest::testFileInfoConstruction_WithoutHash() {
   fs::path fPath = "TestFiles/testfile1.txt";
   QString fType = QString::fromStdString(fPath.extension().string());
   uintmax_t fSize = fs::file_size(fPath);
-  QDateTime dateFound = QDateTime::currentDateTime();
 
-  FileInfo fileInfo(fPath, fType, fSize, dateFound);
+  FileInfo fileInfo(fPath, fType, fSize);
 
   QCOMPARE(fileInfo.getFilePath(), fPath);
   QCOMPARE(fileInfo.getFileType(), fType);
   QCOMPARE(fileInfo.getFileSize(), fSize);
   QCOMPARE(fileInfo.getHash(), DEAD_HASH);
-  QCOMPARE(fileInfo.getDate(), dateFound);
 }
 void FileManagerTest::testFileInfoConstruction_WithHash() {
   fs::path fPath = "TestFiles/testfile1.txt";
   QString fType = QString::fromStdString(fPath.extension().string());
   uintmax_t fSize = fs::file_size(fPath);
   QByteArray hash = QByteArray::fromHex("1234567890abcdef");
-  QDateTime dateFound = QDateTime::currentDateTime();
 
-  FileInfo fileInfo(fPath, fType, fSize, hash, dateFound);
+  FileInfo fileInfo(fPath, fType, fSize, hash);
 
   QCOMPARE(fileInfo.getFilePath(), fPath);
   QCOMPARE(fileInfo.getFileType(), fType);
   QCOMPARE(fileInfo.getFileSize(), fSize);
   QVERIFY(fileInfo.getHash() != DEAD_HASH);
   QCOMPARE(fileInfo.getHash(), hash);
-  QCOMPARE(fileInfo.getDate(), dateFound);
 }
 
 void FileManagerTest::testFileInfoGetters() {
   fs::path fPath = "TestFiles/testfile1.txt";
   QString fType = QString::fromStdString(fPath.extension().string());
   uintmax_t fSize = fs::file_size(fPath);
-  QDateTime dateFound = QDateTime::currentDateTime();
 
-  FileInfo fileInfo(fPath, fType, fSize, dateFound);
+  FileInfo fileInfo(fPath, fType, fSize);
 
   QCOMPARE(fileInfo.getFilePath(), fPath);
   QCOMPARE(fileInfo.getFileType(), fType);
   QCOMPARE(fileInfo.getFileSize(), fSize);
   QCOMPARE(fileInfo.getHash(), DEAD_HASH);
-  QCOMPARE(fileInfo.getDate(), dateFound);
 }
 
 void FileManagerTest::testFileInfoSetHash() {
   fs::path fPath = "TestFiles/testfile1.txt";
   QString fType = QString::fromStdString(fPath.extension().string());
   uintmax_t fSize = fs::file_size(fPath);
-  QDateTime dateFound = QDateTime::currentDateTime();
   QByteArray hash = QByteArray::fromHex("1234567890abcdef");
 
-  FileInfo fileInfo(fPath, fType, fSize, dateFound);
+  FileInfo fileInfo(fPath, fType, fSize);
 
   fileInfo.setHash(hash);
   QVERIFY(fileInfo.getHash() != DEAD_HASH);
@@ -311,15 +302,27 @@ void FileManagerTest::testFileInfoComparisonOperators() {
   uintmax_t fileSize = 1024;
   QByteArray hash1 = QByteArray::fromHex("1234567890abcdef");
   QByteArray hash2 = QByteArray::fromHex("abcdef1234567890");
-  QDateTime dateFound = QDateTime::currentDateTime();
 
   // Create 3 files with 2 being duplciates
-  FileInfo fileInfo1(filePath1, fileType, fileSize, hash1, dateFound);
-  FileInfo fileInfo2(filePath2, fileType, fileSize, hash2, dateFound);
-  FileInfo fileInfoDup(filePath1, fileType, fileSize, hash1, dateFound);
+  FileInfo fileInfo1(filePath1, fileType, fileSize, hash1);
+  FileInfo fileInfo2(filePath2, fileType, fileSize, hash2);
+  FileInfo fileInfoDup(filePath1, fileType, fileSize, hash1);
   // Check FileInfo's defined operators
   QVERIFY(fileInfo1 < fileInfo2);
   QVERIFY(fileInfo1 == fileInfoDup);
+}
+
+void FileManagerTest::testFileInfoDateCreated() {
+    qDebug("test date created is correct");
+    fs::path fPath = fs::current_path() / "TestFiles/testfile1.txt";
+    FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
+                  fs::file_size(fPath),
+                  testManager.HashFile("TestFiles/testfile1.txt"));
+    // get date for test
+    QFileInfo fileInfo(QString::fromStdString(fPath));
+    QDateTime time = fileInfo.birthTime();
+
+    QCOMPARE(file.getDate(), time);
 }
 
 void FileManagerTest::testTreeWidgetHierarchy() {

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -355,7 +355,7 @@ void FileManagerTest::testFileInfoDateCreated() {
                   fs::file_size(fPath),
                   testManager.HashFile("TestFiles/testfile1.txt"));
     // get date for test
-    QFileInfo fileInfo(QString::fromStdString(fPath));
+    QFileInfo fileInfo(QString::fromStdString(fPath.string()));
     QDateTime time = fileInfo.birthTime();
 
     QCOMPARE(file.getDate(), time);

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -182,8 +182,7 @@ void FileManagerTest::testInitAddFileToList() {
     fs::path fPath = fs::current_path() / "TestFiles/testfile1.txt";
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                   fs::file_size(fPath),
-                  testManager.HashFile("TestFiles/testfile1.txt"),
-                  QDateTime::currentDateTime());
+                  testManager.HashFile("TestFiles/testfile1.txt"));
 
     // add test file to list
     testManager.addFileToList(file);
@@ -233,20 +232,17 @@ void FileManagerTest::testAddNonDupeToAddFileToList() {
     fs::path fPath = fs::current_path() / "TestFiles/testfile1.txt";
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                   fs::file_size(fPath),
-                  testManager.HashFile("TestFiles/testfile1.txt"),
-                  QDateTime::currentDateTime());
+                  testManager.HashFile("TestFiles/testfile1.txt"));
 
     fs::path fPathDupe = fs::current_path() / "TestFiles/testfile3.txt";
     FileInfo fileDupe(
         fPathDupe, QString::fromStdString(fPathDupe.extension().string()),
-        fs::file_size(fPathDupe), testManager.HashFile("TestFiles/testfile3.txt"),
-        QDateTime::currentDateTime());
+        fs::file_size(fPathDupe), testManager.HashFile("TestFiles/testfile3.txt"));
 
     fs::path fPathDiff = fs::current_path() / "TestFiles/testfile2.txt";
     FileInfo fileDiff(
         fPathDiff, QString::fromStdString(fPathDiff.extension().string()),
-        fs::file_size(fPathDiff), testManager.HashFile("TestFiles/testfile2.txt"),
-        QDateTime::currentDateTime());
+        fs::file_size(fPathDiff), testManager.HashFile("TestFiles/testfile2.txt"));
 
     qDebug(
         "testAddFileToList verifying non-duplicate goes to different size list");

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -120,6 +120,16 @@ void FileManager::AddDupesToMap(std::list<FileInfo>& list) {
     // add only duplicates (lists with more than 1 file)
     for (auto& [hash, dList] : hashToFilesMap) {
         if (dList.size() > 1) {
+            // move original item to 1st element in list
+            auto earliest = std::min_element(dList.begin(), dList.end(),
+                                                [] (const FileInfo& l, const FileInfo& r) {
+                return l.getDate() < r.getDate();
+            });
+
+            if (earliest != dList.end()) {
+                dList.splice(dList.begin(), dList, earliest);
+            }
+
             Dupes[hash] = dList;
         }
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -83,9 +83,8 @@ void MainWindow::onPushButtonClicked() {
   for (int i = 0; i < filePaths.size(); ++i) {
     // setup for FileInfo class
     fs::path fPath = filePaths[i].toStdString();
-    QDateTime currentDateTime = QDateTime::currentDateTime();
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
-                  fs::file_size(fPath), currentDateTime);
+                  fs::file_size(fPath));
     // Push and sort FileInfo class into FileManager class
     manager->addFileToList(file);  // passes in fileinfo
     // std::cout << *manager;  // DEBUG *************

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -116,13 +116,9 @@ void MainWindow::onPushButtonClicked() {
 void MainWindow::ShowDupesInUI(const FileManager &f) {
   QString out;
   for (auto it = f.Dupes.begin(); it != f.Dupes.end(); ++it) {
-    // Dupes groups by {hash: list<fileinfo>}
-
-    // Get the key to the map (the hash)
-    QString hashGroup = QString(it->first);
     // Make a parent item for the list tree widget
     QTreeWidgetItem *parentHashItem = new QTreeWidgetItem(ui->treeWidget);
-    parentHashItem->setText(0, "Group: " + hashGroup);
+    parentHashItem->setText(0, QString::fromStdString(it->second.front().getFilePath().string()));
     parentHashItem->setText(
         1, "{Placeholder}");  // Next column value to go under Date Modified
     parentHashItem->setCheckState(0, Qt::Unchecked);  // Default unchecked


### PR DESCRIPTION
- changes _DateFound to _DateCreated and implements Qt library getFileCreationDate()
- get date created upon creating FileInfo object
- updates constructors & tests
- uses date created to put original file as 1st element in each list of duplicate files in the Dupes map
- shows original file to UI instead of hash group