### PR TITLE
Safe guards and UI edits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         filemanager.hpp filemanager.cpp
         FileInfo.hpp
         settings.hpp settings.cpp settings.ui
+        tutorial.hpp tutorial.cpp tutorial.ui
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET Replica-Reaper APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
         ${PROJECT_SOURCES}
         filemanager.hpp filemanager.cpp
         FileInfo.hpp
+        settings.hpp settings.cpp settings.ui
     )
 # Define target properties for Android with Qt 6 as:
 #    set_property(TARGET Replica-Reaper APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR

--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -37,6 +37,9 @@ class FileInfo {
     const QDateTime& getDate() const { return _DateCreated; }
     const QString& getFileType() const { return _FileType; }
     const uintmax_t& getFileSize() const { return _FileSize; }
+    QString getFileName() const {
+        return QString::fromStdString(_FilePath.filename().string());
+    }
 
     void setHash(const QByteArray& h) { _Hash = h; }
 

--- a/FileInfo.hpp
+++ b/FileInfo.hpp
@@ -1,5 +1,4 @@
 // Copyright 2025 Replica Reaper
-#pragma once
 #ifndef FILEINFO_HPP
 #define FILEINFO_HPP
 #include <QString>

--- a/UnitTest/CMakeLists.txt
+++ b/UnitTest/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # 3. add another add executable line (below)
 # Ex. If <somefile>.cpp has " #include ../<someheader>.h "
 # add_executable(UnitTests ... ... "tst_<somefile>.cpp"  "../<whatever was inluded mathcing cpp file>.cpp" )
-add_executable(UnitTests tst_filemanager.cpp ../filemanager.cpp ../mainwindow.cpp ../settings.cpp)
+add_executable(UnitTests tst_filemanager.cpp ../filemanager.cpp ../mainwindow.cpp ../settings.cpp ../tutorial.cpp)
 target_link_libraries(UnitTests PRIVATE Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Test Qt${QT_VERSION_MAJOR}::Widgets)
 
 #<--- This line implements the whole file as ONE test case for Ctest--->

--- a/UnitTest/CMakeLists.txt
+++ b/UnitTest/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # 3. add another add executable line (below)
 # Ex. If <somefile>.cpp has " #include ../<someheader>.h "
 # add_executable(UnitTests ... ... "tst_<somefile>.cpp"  "../<whatever was inluded mathcing cpp file>.cpp" )
-add_executable(UnitTests tst_filemanager.cpp ../filemanager.cpp ../mainwindow.cpp)
+add_executable(UnitTests tst_filemanager.cpp ../filemanager.cpp ../mainwindow.cpp ../settings.cpp)
 target_link_libraries(UnitTests PRIVATE Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Test Qt${QT_VERSION_MAJOR}::Widgets)
 
 #<--- This line implements the whole file as ONE test case for Ctest--->

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -43,7 +43,7 @@ class FileManagerTest : public QObject {
   void testListFilesFail();
   void testInitAddFileToList();
   void testAddDupeToAddFileToList();
-  void testAddNonDupeToAddFileToList();
+  void testAddNonDupeToaddFileToTypeSizeMap();
 
   // UI Components Tests:
   void testProgressBarUpdate();
@@ -185,7 +185,7 @@ void FileManagerTest::testInitAddFileToList() {
                   testManager.HashFile("TestFiles/testfile1.txt"));
 
     // add test file to list
-    testManager.addFileToList(file);
+    testManager.addFileToTypeSizeMap(file);
 
     // verify file type has 1 entry
     QVERIFY(testManager.AllFilesByTypeSize[file.getFileType()][file.getFileSize()]
@@ -220,14 +220,14 @@ void FileManagerTest::testAddDupeToAddFileToList() {
   qDebug("testAddFileToList verifying duplicate goes to the same list");
 
   // add test file to list
-  testManager.addFileToList(fileDupe);
+  testManager.addFileToTypeSizeMap(fileDupe);
 
   // verify type and size have 2 entries
   QVERIFY(testManager.AllFilesByTypeSize[file.getFileType()][file.getFileSize()]
               .size() == 2);
 }
 
-void FileManagerTest::testAddNonDupeToAddFileToList() {
+void FileManagerTest::testAddNonDupeToaddFileToTypeSizeMap() {
     // create test files to ensure its added correctly
     fs::path fPath = fs::current_path() / "TestFiles/testfile1.txt";
     FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
@@ -245,10 +245,10 @@ void FileManagerTest::testAddNonDupeToAddFileToList() {
         fs::file_size(fPathDiff), testManager.HashFile("TestFiles/testfile2.txt"));
 
     qDebug(
-        "testAddFileToList verifying non-duplicate goes to different size list");
+        "testaddFileToTypeSizeMap verifying non-duplicate goes to different size list");
 
     // add different test file to list
-    testManager.addFileToList(fileDiff);
+    testManager.addFileToTypeSizeMap(fileDiff);
 
     // test files at different location
     QVERIFY(testManager.AllFilesByTypeSize[file.getFileType()][file.getFileSize()]

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -34,6 +34,13 @@ QString FileManager::PromptDirectory(QWidget* parent) {
         return QString();
     }
 
+    QDir dir(filePath);
+    if (dir.isRoot()){
+        qDebug() << "Root directory selection is not allowed.";
+        return QString();
+    }
+
+
   qDebug() << "Selected File Path: " << filePath;
   return filePath;
 }

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -40,7 +40,6 @@ QString FileManager::PromptDirectory(QWidget* parent) {
         return QString();
     }
 
-
   qDebug() << "Selected File Path: " << filePath;
   return filePath;
 }

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -4,168 +4,168 @@
 
 FileManager::FileManager(QObject* parent)
     : QObject(parent), trayIcon(new QSystemTrayIcon()), ui(nullptr) {
-  // can also set our custon icon like this:
-  // trayIcon->setIcon(QIcon(":/icon.png")); // Set an icon (optional, ensure
-  // the path is correct sets a standard tray icon for now
-  this->trayIcon->setIcon(
-      QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation));
-  quitAction = new QAction("Exit Replica Reaper", this);
-  // map the action to close the full application, (qApp is a universal pointer
-  // to the running application)
-  connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
-  // add a trayicon menu with the quit button/action
-  QMenu* trayMenu = new QMenu();
-  trayMenu->addAction(quitAction);
-  trayIcon->setContextMenu(trayMenu);
-  // map the user clicking the tray icon to a function reopening the UI
-  connect(trayIcon, &QSystemTrayIcon::activated, this,
+    // can also set our custon icon like this:
+    // trayIcon->setIcon(QIcon(":/icon.png")); // Set an icon (optional, ensure
+    // the path is correct sets a standard tray icon for now
+    this->trayIcon->setIcon(
+        QApplication::style()->standardIcon(QStyle::SP_MessageBoxInformation));
+     quitAction = new QAction("Exit Replica Reaper", this);
+    // map the action to close the full application, (qApp is a universal pointer
+    // to the running application)
+    connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
+    // add a trayicon menu with the quit button/action
+    QMenu* trayMenu = new QMenu();
+    trayMenu->addAction(quitAction);
+    trayIcon->setContextMenu(trayMenu);
+    // map the user clicking the tray icon to a function reopening the UI
+    connect(trayIcon, &QSystemTrayIcon::activated, this,
           &FileManager::onTrayIconActivated);
-  this->trayIcon->show();
+    this->trayIcon->show();
 }
 FileManager::~FileManager() {}
 
 QString FileManager::PromptDirectory(QWidget* parent) {
-  QString filePath = QFileDialog::getExistingDirectory(
-      parent, "Open a Directory", QDir::homePath(),
-      QFileDialog::DontResolveSymlinks);
+    QString filePath = QFileDialog::getExistingDirectory(
+        parent, "Open a Directory", QDir::homePath(),
+        QFileDialog::DontResolveSymlinks);
 
-  if (filePath.isEmpty()) {
-    qDebug() << "No directory selected";
-    return QString();
-  }
+    if (filePath.isEmpty()) {
+        qDebug() << "No directory selected";
+        return QString();
+    }
 
-  QDir dir(filePath);
-  if (dir.isRoot()) {
-    qDebug() << "Root directory selection is not allowed.";
-    return QString();
-  }
+    QDir dir(filePath);
+    if (dir.isRoot()) {
+        qDebug() << "Root directory selection is not allowed.";
+        return QString();
+    }
 
-  qDebug() << "Selected File Path: " << filePath;
-  return filePath;
+    qDebug() << "Selected File Path: " << filePath;
+    return filePath;
 }
 
 QByteArray FileManager::HashFile(QString fileName) {
-  // Opens the file
-  QFile file(fileName);
-  // sets the hash generator
-  QCryptographicHash hash(QCryptographicHash::Sha256);
+    // Opens the file
+    QFile file(fileName);
+    // sets the hash generator
+    QCryptographicHash hash(QCryptographicHash::Sha256);
 
-  if (!file.open(QIODevice::ReadOnly)) {
-    qWarning() << "Could not open file:" << fileName;
-    return QByteArray("");
-  }
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning() << "Could not open file:" << fileName;
+        return QByteArray("");
+    }
 
-  if (!hash.addData(&file)) {
-    qWarning() << "Could not sha256 hash the file";
-    return QByteArray("");
-  }
+    if (!hash.addData(&file)) {
+        qWarning() << "Could not sha256 hash the file";
+        return QByteArray("");
+    }
 
-  QByteArray result = hash.result().toHex();
-  file.close();
-  return result;
+    QByteArray result = hash.result().toHex();
+    file.close();
+    return result;
 }
 
 QStringList FileManager::ListFiles(const QString& directoryPath) {
-  QDir dir(directoryPath);
-  if (!dir.exists()) {
-    qWarning() << "Directory does not exist:" << directoryPath;
-    return QStringList();
-  }
+    QDir dir(directoryPath);
+    if (!dir.exists()) {
+        qWarning() << "Directory does not exist:" << directoryPath;
+        return QStringList();
+    }
 
-  QStringList fullPaths;
-  QDirIterator it(directoryPath, QDir::Files | QDir::NoDotAndDotDot,
-                  QDirIterator::Subdirectories);
+    QStringList fullPaths;
+    QDirIterator it(directoryPath, QDir::Files | QDir::NoDotAndDotDot,
+                    QDirIterator::Subdirectories);
 
-  while (it.hasNext()) {
-    fullPaths.append(it.next());
-  }
+    while (it.hasNext()) {
+        fullPaths.append(it.next());
+    }
 
-  // qDebug() << "Files in directory (recursive):" << fullPaths;
-  return fullPaths;
+    // qDebug() << "Files in directory (recursive):" << fullPaths;
+    return fullPaths;
 }
 
 void FileManager::addFileToList(FileInfo& file) {
-  auto& sizeMap =
-      AllFilesByTypeSize[file.getFileType()];  // list of same size file types
-  auto& fileList =
-      sizeMap[file.getFileSize()];  // list of same-sized file infos
+    auto& sizeMap =
+        AllFilesByTypeSize[file.getFileType()];  // list of same size file types
+    auto& fileList =
+        sizeMap[file.getFileSize()];  // list of same-sized file infos
 
-  fileList.push_back(file);
+    fileList.push_back(file);
 
-  // Check for duplicates (if list has more than one file now)
-  if (fileList.size() > 1) CheckAndAddDupes(fileList);
+    // Check for duplicates (if list has more than one file now)
+    if (fileList.size() > 1) CheckAndAddDupes(fileList);
 }
 
 void FileManager::CheckAndAddDupes(std::list<FileInfo>& list) {
-  // Ensure each file in the list has a valid hash
-  UpdateHashes(list);
+    // Ensure each file in the list has a valid hash
+    UpdateHashes(list);
 
-  list.sort();
+    list.sort();
 
-  // std::unordered_set<QByteArray> HashList = StoreUniqueHashes(list);
+    // std::unordered_set<QByteArray> HashList = StoreUniqueHashes(list);
 
-  AddDupesToMap(list);
+    AddDupesToMap(list);
 }
 
 void FileManager::UpdateHashes(std::list<FileInfo>& list) {
-  for (auto& f : list) {
-    if (f.getHash() == DEAD_HASH)
-      f.setHash(HashFile(QString::fromStdString(f.getFilePath().string())));
-  }
+    for (auto& f : list) {
+        if (f.getHash() == DEAD_HASH)
+            f.setHash(HashFile(QString::fromStdString(f.getFilePath().string())));
+    }
 }
 
 void FileManager::AddDupesToMap(std::list<FileInfo>& list) {
-  // Hash map implementation:
-  std::unordered_map<QByteArray, std::list<FileInfo>> hashToFilesMap;
+    // Hash map implementation:
+    std::unordered_map<QByteArray, std::list<FileInfo>> hashToFilesMap;
 
-  // convert the FileInfo list into a map with the file hash as the key
-  for (auto& file : list) {
-    // hash key
-    const QByteArray& hash = file.getHash();
-    hashToFilesMap[hash].push_back(file);
-  }
-  // Iterate through the of hash keys and
-  // add only duplicates (lists with more than 1 file)
-  for (auto& [hash, dList] : hashToFilesMap) {
-    if (dList.size() > 1) {
-      // move original item to 1st element in list
-      auto earliest = std::min_element(
-          dList.begin(), dList.end(), [](const FileInfo& l, const FileInfo& r) {
-            return l.getDate() < r.getDate();
-          });
-
-      if (earliest != dList.end()) {
-        dList.splice(dList.begin(), dList, earliest);
-      }
-
-      Dupes[hash] = dList;
+    // convert the FileInfo list into a map with the file hash as the key
+    for (auto& file : list) {
+        // hash key
+        const QByteArray& hash = file.getHash();
+        hashToFilesMap[hash].push_back(file);
     }
-  }
+    // Iterate through the of hash keys and
+    // add only duplicates (lists with more than 1 file)
+    for (auto& [hash, dList] : hashToFilesMap) {
+        if (dList.size() > 1) {
+            // move original item to 1st element in list
+            auto earliest = std::min_element(
+                dList.begin(), dList.end(), [](const FileInfo& l, const FileInfo& r) {
+                return l.getDate() < r.getDate();
+            });
+
+        if (earliest != dList.end()) {
+            dList.splice(dList.begin(), dList, earliest);
+        }
+
+        Dupes[hash] = dList;
+        }
+    }
 }
 
 std::ostream& operator<<(std::ostream& out, const FileManager& f) {
-  for (const auto& [fileType, MapSize] : f.AllFilesByTypeSize) {
-    out << "File Type: " << fileType.toStdString() << "\n";
-    for (const auto& [fileSize, fileList] : MapSize) {
-      out << "  Size: " << fileSize << " bytes\n";
-      for (const auto& file : fileList) {
-        out << "    - " << file.getFilePath() << "\n";
-      }
+    for (const auto& [fileType, MapSize] : f.AllFilesByTypeSize) {
+        out << "File Type: " << fileType.toStdString() << "\n";
+        for (const auto& [fileSize, fileList] : MapSize) {
+            out << "  Size: " << fileSize << " bytes\n";
+            for (const auto& file : fileList) {
+                out << "    - " << file.getFilePath() << "\n";
+            }
+        }
     }
-  }
   return out;
 }
 
 void FileManager::ShowNotification(const QString& title,
-                                   const QString& message) {
-  if (!QSystemTrayIcon::isSystemTrayAvailable()) {
-    qWarning("System tray is not available.");
-    return;
-  }
+                                    const QString& message) {
+    if (!QSystemTrayIcon::isSystemTrayAvailable()) {
+        qWarning("System tray is not available.");
+        return;
+    }
 
-  // Display the notification | 10000 ms = 10 seconds till timeout
-  this->trayIcon->showMessage(title, message, QSystemTrayIcon::Information,
-                              10000);
+    // Display the notification | 10000 ms = 10 seconds till timeout
+    this->trayIcon->showMessage(title, message, QSystemTrayIcon::Information,
+                                10000);
 }
 // This file should add to the qlist of qlists of FileInfos
 // if a duplicate isnt found already in here an exception is thrown
@@ -174,18 +174,18 @@ void FileManager::AddToDupes(const FileInfo& File) { return; }
 // this function activates when the system tray icon is clicked
 void FileManager::onTrayIconActivated(
     QSystemTrayIcon::ActivationReason reason) {
-  // if the icon is clicked and the ui exists
-  if (reason == QSystemTrayIcon::Trigger && ui) {
-    // If the main window is hidden or minimized, show it
-    if (ui->isHidden()) {
-      ui->show();            // Show the window if hidden
-      ui->raise();           // Bring the window to the front
-      ui->activateWindow();  // Give the window focus
-    } else {
-      ui->raise();
-      ui->activateWindow();
+    // if the icon is clicked and the ui exists
+    if (reason == QSystemTrayIcon::Trigger && ui) {
+        // If the main window is hidden or minimized, show it
+        if (ui->isHidden()) {
+            ui->show();            // Show the window if hidden
+            ui->raise();           // Bring the window to the front
+            ui->activateWindow();  // Give the window focus
+        } else {
+            ui->raise();
+            ui->activateWindow();
+        }
     }
-  }
 }
 // allows access to show and hide the UI
 void FileManager::setMainWindow(QMainWindow* ui) { this->ui = ui; }

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -181,9 +181,9 @@ void FileManager::onTrayIconActivated(
       ui->show();            // Show the window if hidden
       ui->raise();           // Bring the window to the front
       ui->activateWindow();  // Give the window focus
-    }else{
-        ui->raise();
-        ui->activateWindow();
+    } else {
+      ui->raise();
+      ui->activateWindow();
     }
   }
 }

--- a/filemanager.cpp
+++ b/filemanager.cpp
@@ -181,6 +181,9 @@ void FileManager::onTrayIconActivated(
       ui->show();            // Show the window if hidden
       ui->raise();           // Bring the window to the front
       ui->activateWindow();  // Give the window focus
+    }else{
+        ui->raise();
+        ui->activateWindow();
     }
   }
 }

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -26,39 +26,41 @@ using std::unordered_map;
 using std::unordered_set;
 
 class FileManager : public QObject {
-    Q_OBJECT
+  Q_OBJECT
 
  public:
-    explicit FileManager(QObject* parent = nullptr);
-    QString PromptDirectory(QWidget* widget);
-    QByteArray HashFile(QString fileName);
-    QStringList ListFiles(const QString& directoryPath);
-    void AddToDupes(const FileInfo& File);
-    void ShowNotification(const QString& title, const QString& message);
-    void addFileToList(FileInfo& file);
-    void CheckAndAddDupes(std::list<FileInfo>& list);
-    void setMainWindow(QMainWindow *ui);
-    void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
-    void AddDupesToMap(std::list<FileInfo>& list);
-    void UpdateHashes(std::list<FileInfo>& list);
-    void ClearData(){ AllFilesByTypeSize.clear(); Dupes.clear();}
-    ~FileManager();
+  explicit FileManager(QObject* parent = nullptr);
+  QString PromptDirectory(QWidget* widget);
+  QByteArray HashFile(QString fileName);
+  QStringList ListFiles(const QString& directoryPath);
+  void AddToDupes(const FileInfo& File);
+  void ShowNotification(const QString& title, const QString& message);
+  void addFileToList(FileInfo& file);
+  void CheckAndAddDupes(std::list<FileInfo>& list);
+  void setMainWindow(QMainWindow* ui);
+  void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+  void AddDupesToMap(std::list<FileInfo>& list);
+  void UpdateHashes(std::list<FileInfo>& list);
+  void ClearData() {
+    AllFilesByTypeSize.clear();
+    Dupes.clear();
+  }
+  ~FileManager();
 
-    friend std::ostream& operator<<(std::ostream& out,
-                const FileManager& f);
+  friend std::ostream& operator<<(std::ostream& out, const FileManager& f);
 
-    unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>> AllFilesByTypeSize;
-    unordered_map<QByteArray, std::list<FileInfo>> Dupes;
+  unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>>
+      AllFilesByTypeSize;
+  unordered_map<QByteArray, std::list<FileInfo>> Dupes;
 
  private:
-    QSystemTrayIcon* trayIcon;
-    QAction* quitAction;
-    QMenu* trayMenu;
-    QMainWindow* ui;
-    // Map filtered by file type and then file size
-    // unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>> AllFilesByTypeSize;
-    // Holds list of list of duplicates
-    // no particular order
+  QSystemTrayIcon* trayIcon;
+  QAction* quitAction;
+  QMenu* trayMenu;
+  QMainWindow* ui;
+  // Map filtered by file type and then file size
+  // unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>>
+  // AllFilesByTypeSize; Holds list of list of duplicates no particular order
 };
 
 #endif /* FILEMANAGER_HPP */

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -1,5 +1,4 @@
 // Copyright 2025 Replica Reaper
-#pragma once
 #ifndef FILEMANAGER_HPP
 #define FILEMANAGER_HPP
 #include <QString>
@@ -26,41 +25,41 @@ using std::unordered_map;
 using std::unordered_set;
 
 class FileManager : public QObject {
-  Q_OBJECT
+    Q_OBJECT
 
  public:
-  explicit FileManager(QObject* parent = nullptr);
-  QString PromptDirectory(QWidget* widget);
-  QByteArray HashFile(QString fileName);
-  QStringList ListFiles(const QString& directoryPath);
-  void AddToDupes(const FileInfo& File);
-  void ShowNotification(const QString& title, const QString& message);
-  void addFileToList(FileInfo& file);
-  void CheckAndAddDupes(std::list<FileInfo>& list);
-  void setMainWindow(QMainWindow* ui);
-  void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
-  void AddDupesToMap(std::list<FileInfo>& list);
-  void UpdateHashes(std::list<FileInfo>& list);
-  void ClearData() {
-    AllFilesByTypeSize.clear();
-    Dupes.clear();
-  }
-  ~FileManager();
+    explicit FileManager(QObject* parent = nullptr);
+    QString PromptDirectory(QWidget* widget);
+    QByteArray HashFile(QString fileName);
+    QStringList ListFiles(const QString& directoryPath);
+    void AddToDupes(const FileInfo& File);
+    void ShowNotification(const QString& title, const QString& message);
+    void addFileToList(FileInfo& file);
+    void CheckAndAddDupes(std::list<FileInfo>& list);
+    void setMainWindow(QMainWindow* ui);
+    void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
+    void AddDupesToMap(std::list<FileInfo>& list);
+    void UpdateHashes(std::list<FileInfo>& list);
+    void ClearData() {
+        AllFilesByTypeSize.clear();
+        Dupes.clear();
+    }
+    ~FileManager();
 
-  friend std::ostream& operator<<(std::ostream& out, const FileManager& f);
+    friend std::ostream& operator<<(std::ostream& out, const FileManager& f);
 
-  unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>>
-      AllFilesByTypeSize;
-  unordered_map<QByteArray, std::list<FileInfo>> Dupes;
+    // Map filtered by file type and then file size
+    // unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>>
+    // AllFilesByTypeSize; Holds list of list of duplicates no particular order
+    unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>>
+        AllFilesByTypeSize;
+    unordered_map<QByteArray, std::list<FileInfo>> Dupes;
 
  private:
-  QSystemTrayIcon* trayIcon;
-  QAction* quitAction;
-  QMenu* trayMenu;
-  QMainWindow* ui;
-  // Map filtered by file type and then file size
-  // unordered_map<QString, unordered_map<uintmax_t, std::list<FileInfo>>>
-  // AllFilesByTypeSize; Holds list of list of duplicates no particular order
+    QSystemTrayIcon* trayIcon;
+    QAction* quitAction;
+    QMenu* trayMenu;
+    QMainWindow* ui;
 };
 
 #endif /* FILEMANAGER_HPP */

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -41,6 +41,7 @@ class FileManager : public QObject {
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void AddDupesToMap(std::list<FileInfo>& list);
     void UpdateHashes(std::list<FileInfo>& list);
+    void ClearData(){ AllFilesByTypeSize.clear(); Dupes.clear();}
     ~FileManager();
 
     friend std::ostream& operator<<(std::ostream& out,

--- a/filemanager.hpp
+++ b/filemanager.hpp
@@ -34,11 +34,10 @@ class FileManager : public QObject {
     QStringList ListFiles(const QString& directoryPath);
     void AddToDupes(const FileInfo& File);
     void ShowNotification(const QString& title, const QString& message);
-    void addFileToList(FileInfo& file);
+    void addFileToTypeSizeMap(FileInfo& file);
     void CheckAndAddDupes(std::list<FileInfo>& list);
     void setMainWindow(QMainWindow* ui);
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
-    void AddDupesToMap(std::list<FileInfo>& list);
     void UpdateHashes(std::list<FileInfo>& list);
     void ClearData() {
         AllFilesByTypeSize.clear();

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ namespace fs = std::filesystem;
 #define DEBUG 1
 
 int main(int argc, char* argv[]) {
-  if (!DEBUG) {
+  if (DEBUG) {
     QApplication app(argc, argv);
     QWidget widget;
     MainWindow window(&widget);

--- a/main.cpp
+++ b/main.cpp
@@ -9,50 +9,47 @@
 namespace fs = std::filesystem;
 
 //  Switch to 1 for testing
-//  currently hardcoded to Braden's machine
-#define DEBUG 1
+//  Switch to 0 for regular program***
+#define DEBUG 0
 
 int main(int argc, char* argv[]) {
-  if (DEBUG) {
-    QApplication app(argc, argv);
-    QWidget widget;
-    MainWindow window(&widget);
-    window.show();
-    return app.exec();
-  } else if (DEBUG) {
-    // This Section is for testing on Machine
-
-    std::vector<QString> list = {
-        QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
-        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
-        QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-        QStandardPaths::writableLocation(QStandardPaths::PicturesLocation)};
-
-    QApplication app(argc, argv);
-    // std::vector<std::string> list = {"C:\\Users\\brade\\Downloads",
-    // "C:\\Users\\brade\\Documents", "C:\\Users\\brade\\Desktop",
-    // "C:\\Users\\brade\\Pictures"};
-    std::ofstream outFile("Performance.csv",
-                          std::ios::app);  // // Open file for writing (will
-                                           // create if it doesn't exist)
-    if (!outFile) {
-      std::cerr << "Error opening the file!" << std::endl;
-      return -1;  // Return with error if file cannot be opened
-    }
-    for (const auto& dir : list) {
-      if (!dir.isEmpty()) {  // Ensure the directory path is valid
-        qint64 time;
-        qint64 size;
+    if (!DEBUG) {
+        QApplication app(argc, argv);
         QWidget widget;
         MainWindow window(&widget);
-        size = window.getDirectorySize(dir);
-        time = window.PythonAutoTestHelper(dir);
-        outFile << dir.toStdString() << std::endl;
-        outFile << static_cast<int64_t>(time) << std::endl;
-        outFile << static_cast<int64_t>(size) << std::endl;
-      }
+        window.show();
+        return app.exec();
+    } else if (DEBUG) {
+        // This Section is for testing on Machine
+
+        std::vector<QString> list = {
+            QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
+            QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
+            QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+            QStandardPaths::writableLocation(QStandardPaths::PicturesLocation)};
+
+        QApplication app(argc, argv);
+        std::ofstream outFile("Performance.csv",
+                          std::ios::app);  // // Open file for writing (will
+                                           // create if it doesn't exist)
+        if (!outFile) {
+            std::cerr << "Error opening the file!" << std::endl;
+            return -1;  // Return with error if file cannot be opened
+        }
+        for (const auto& dir : list) {
+            if (!dir.isEmpty()) {  // Ensure the directory path is valid
+                qint64 time;
+                qint64 size;
+                QWidget widget;
+                MainWindow window(&widget);
+                size = window.getDirectorySize(dir);
+                time = window.PythonAutoTestHelper(dir);
+                outFile << dir.toStdString() << std::endl;
+                outFile << static_cast<int64_t>(time) << std::endl;
+                outFile << static_cast<int64_t>(size) << std::endl;
+            }
+        }
+        outFile.close();
+        return app.exec();
     }
-    outFile.close();
-    return app.exec();
-  }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,4 @@
 // Copyright 2025 Replica Reaper
-#include <QStandardPaths>
-#include <QString>
-#include <vector>
-#include <string>
-#include <fstream>
 #include "mainwindow.hpp"
 
 namespace fs = std::filesystem;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -6,6 +6,7 @@ MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::MainWindow), manager(new FileManager()) {
   ui->setupUi(this);
   ui->progressBar->setValue(0);
+  this->setWindowTitle("Replica Reaper");
   manager->setMainWindow(this);
   // set the "Run in background" checkbox to true
   ui->checkBox->setChecked(true);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -68,6 +68,7 @@ void MainWindow::onPushButtonClicked() {
     qDebug("Please select a directory");
     return;
   }
+
   QStringList filePaths = manager->ListFiles(path);
 
   // Set up the progress bar

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -62,6 +62,8 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
 void MainWindow::onPushButtonClicked() {
   qDebug() << "Button clicked!";
+  // clear the tree widget
+  ui->treeWidget->clear();
 
   QString path = manager->PromptDirectory(this);
   if (path == QString()) {
@@ -112,6 +114,8 @@ void MainWindow::onPushButtonClicked() {
   ShowDupesInUI(*manager);
   // re-enable the button
   ui->RunReaperBTN->setEnabled(true);
+  // clear the filemanager maps
+  manager->ClearData();
 }
 
 // adds one file to qlistwidget

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -215,12 +215,13 @@ void MainWindow::onTreeItemChanged(QTreeWidgetItem *item) {
 
 void MainWindow::onDelSelBTN_clicked() {
   // prints selected to console for now
-  //printCheckedItems();
+  // printCheckedItems();
   auto files = getCheckedItems();
   // dont show the dialoge if no files are selected
   if (files.empty()) {
-      QMessageBox::information(this, "No Selection", "Please select at least one file to delete.");
-      return;
+    QMessageBox::information(this, "No Selection",
+                             "Please select at least one file to delete.");
+    return;
   }
   showDeleteConfirmation(files);
 }
@@ -267,7 +268,7 @@ list<pair<QString, QString>> MainWindow::getCheckedItems() {
         auto filename = childItem->text(0);
         auto filepath = childItem->text(1);
         // add pairs to files
-        std::pair<QString,QString> pair(filename, filepath);
+        std::pair<QString, QString> pair(filename, filepath);
         files.push_back(pair);
       }
     }
@@ -331,53 +332,59 @@ void MainWindow::setBackgroundState(bool state) {
   this->backgroundCheck = state;
 }
 
-void MainWindow::showDeleteConfirmation(const list<pair<QString, QString>>& files) {
-    QDialog dialog(this);
-    dialog.setWindowTitle("Confirm Deletion");
-    dialog.setModal(true);
-    dialog.setMinimumSize(400, 300);
+void MainWindow::showDeleteConfirmation(
+    const list<pair<QString, QString>> &files) {
+  QDialog dialog(this);
+  dialog.setWindowTitle("Confirm Deletion");
+  dialog.setModal(true);
+  dialog.setMinimumSize(400, 300);
 
-    QVBoxLayout* layout = new QVBoxLayout(&dialog);
+  QVBoxLayout *layout = new QVBoxLayout(&dialog);
 
-    QLabel* label = new QLabel("Are you sure you want to delete the following files?");
-    layout->addWidget(label);
+  QLabel *label =
+      new QLabel("Are you sure you want to delete the following files?");
+  layout->addWidget(label);
 
-    QListWidget* listWidget = new QListWidget();
-    // Only add the first element of each pair (filename)
+  QListWidget *listWidget = new QListWidget();
+  // Only add the first element of each pair (filename)
+  for (const auto &filePair : files) {
+    listWidget->addItem(filePair.first);
+  }
+  layout->addWidget(listWidget);
+
+  QDialogButtonBox *buttonBox =
+      new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No);
+  layout->addWidget(buttonBox);
+
+  QObject::connect(buttonBox, &QDialogButtonBox::accepted, &dialog,
+                   &QDialog::accept);
+  QObject::connect(buttonBox, &QDialogButtonBox::rejected, &dialog,
+                   &QDialog::reject);
+
+  if (dialog.exec() == QDialog::Accepted) {
+    // temperary "success flag"
+    QMessageBox::information(this, "Success",
+                             "Selected files deleted successfully.");
+    // Delete files
+    // Deleting File Logic:
+    /*
+    QStringList failedDeletions;
+
     for (const auto& filePair : files) {
-        listWidget->addItem(filePair.first);
-    }
-    layout->addWidget(listWidget);
-
-    QDialogButtonBox* buttonBox = new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No);
-    layout->addWidget(buttonBox);
-
-    QObject::connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-    QObject::connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
-
-    if (dialog.exec() == QDialog::Accepted) {
-        // temperary "success flag"
-        QMessageBox::information(this, "Success", "Selected files deleted successfully.");
-        // Delete files
-        // Deleting File Logic:
-        /*
-        QStringList failedDeletions;
-
-        for (const auto& filePair : files) {
-            QString fullPath = filePair.second;
-            QFile file(fullPath);
-            if (!file.remove()) {
-                failedDeletions.append(fullPath);
-            }
+        QString fullPath = filePair.second;
+        QFile file(fullPath);
+        if (!file.remove()) {
+            failedDeletions.append(fullPath);
         }
-
-        if (!failedDeletions.isEmpty()) {
-            QString errorMsg = "Failed to delete the following files:\n" + failedDeletions.join("\n");
-            QMessageBox::warning(this, "Deletion Failed", errorMsg);
-        } else {
-            QMessageBox::information(this, "Success", "Selected files deleted successfully.");
-        }*/
-    } else {
-        // Canceled
     }
+
+    if (!failedDeletions.isEmpty()) {
+        QString errorMsg = "Failed to delete the following files:\n" +
+    failedDeletions.join("\n"); QMessageBox::warning(this, "Deletion Failed",
+    errorMsg); } else { QMessageBox::information(this, "Success", "Selected
+    files deleted successfully.");
+    }*/
+  } else {
+    // Canceled
+  }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -258,17 +258,17 @@ list<pair<QString, QString>> MainWindow::getCheckedItems() {
     // iterate through child items of the checked parent
     for (int j = 0; j < parentItem->childCount(); ++j) {
       QTreeWidgetItem *childItem = parentItem->child(j);
-      auto filename = childItem->text(0);
-      auto filepath = childItem->text(1);
-      // add pairs to files
-      std::pair<QString,QString> pair(filename, filepath);
-      files.push_back(pair);
 
       // Skip if the child is unchecked (for partially checked cases)
       if (childItem->checkState(0) == Qt::Unchecked) {
         continue;
       } else {  // child is checked
         qDebug() << "Checked Item:" << childItem->text(0);
+        auto filename = childItem->text(0);
+        auto filepath = childItem->text(1);
+        // add pairs to files
+        std::pair<QString,QString> pair(filename, filepath);
+        files.push_back(pair);
       }
     }
   }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -8,8 +8,8 @@ MainWindow::MainWindow(QWidget *parent)
   ui->progressBar->setValue(0);
   this->setWindowTitle("Replica Reaper");
   manager->setMainWindow(this);
-  // set the "Run in background" checkbox to true
-  ui->checkBox->setChecked(true);
+  // sets the background state
+  this->backgroundCheck = false;
 
   // Tree Widget config:
   ui->treeWidget->setColumnCount(3);  // Single column for file names
@@ -59,7 +59,7 @@ MainWindow::~MainWindow() {
 // Overloaded function that automatically gets called when user closes UI
 void MainWindow::closeEvent(QCloseEvent *event) {
   // if the "Run in Background" button is checked,
-  if (ui->checkBox->isChecked()) {
+  if (this->backgroundCheck) {
     // If checked, just close the window (keeps running in bacnground)
     event->accept();  // Accept the event, which will close the window
   } else {
@@ -299,3 +299,16 @@ qint64 MainWindow::getDirectorySize(const QString &dirPath) {
 
   return totalSize;
 }
+
+void MainWindow::on_SettBTN_clicked()
+{
+    Settings* settings = new Settings(this);
+    settings->setState(this->backgroundCheck);
+    settings->setModal(true);
+    settings->exec();
+}
+
+void MainWindow::setBackgroundState(bool state){
+    this->backgroundCheck = state;
+}
+

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,9 +12,14 @@ MainWindow::MainWindow(QWidget *parent)
 
   // Tree Widget config:
   ui->treeWidget->setColumnCount(
-      2);  // Single column for file names (Poss another col for Date Modified)
+      3);  // Single column for file names
+  // Make columns resizable
+  ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::Interactive);  // Filename
+  ui->treeWidget->header()->setSectionResizeMode(1, QHeaderView::Interactive);  // File Path
+  ui->treeWidget->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);  // Date Modified
+  ui->treeWidget->header()->setMaximumSectionSize(300);
   ui->treeWidget->setHeaderLabels(
-      {"File Path", "Date Modified"});  // tree columns
+      {"Filename","File Path", "Date Modified"});  // tree columns
   ui->treeWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   ui->treeWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   ui->treeWidget->header()->setSectionResizeMode(
@@ -130,9 +135,10 @@ void MainWindow::ShowDupesInUI(const FileManager &f) {
     // Make a parent item for the list tree widget
     QTreeWidgetItem *parentHashItem = new QTreeWidgetItem(ui->treeWidget);
     parentHashItem->setText(
-        0, QString::fromStdString(it->second.front().getFilePath().string()));
+        0, it->second.front().getFileName());
     parentHashItem->setText(
-        1, "{Placeholder}");  // Next column value to go under Date Modified
+        1, QString::fromStdString(it->second.front().getFilePath().string()));  // Next column value to go under FilePath
+    parentHashItem->setText(2, it->second.front().getDate().toString());
     parentHashItem->setCheckState(0, Qt::Unchecked);  // Default unchecked
     // add the parent item to tree
     ui->treeWidget->addTopLevelItem(parentHashItem);
@@ -142,12 +148,18 @@ void MainWindow::ShowDupesInUI(const FileManager &f) {
       // Logic for adding to list Tree:
       // make a a child for the parent hash item
       QTreeWidgetItem *childItem = new QTreeWidgetItem(parentHashItem);
-      childItem->setText(0, out);  // set the filepath
+      childItem->setText(0, a.getFileName());  // set the filename
       childItem->setText(
-          1, QString("{Date Modified}"));  // Next column value for child item
+          1, out); // sets the filepath column
+      childItem->setText(2,a.getDate().toString());
       childItem->setCheckState(0, Qt::Unchecked);
     }
   }
+  ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);  // Filename
+  ui->treeWidget->header()->setSectionResizeMode(1, QHeaderView::Interactive);  // File Path
+  ui->treeWidget->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);  // Date Modified
+  ui->treeWidget->setColumnWidth(1,200);
+  ui->treeWidget->setColumnWidth(2,150);
 }
 
 // Function to manage parent-child checkbox behavior

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -68,6 +68,9 @@ void MainWindow::onPushButtonClicked() {
     qDebug("Please select a directory");
     return;
   }
+  // disable the button before reaping
+  ui->RunReaperBTN->setEnabled(false);
+
 
   QStringList filePaths = manager->ListFiles(path);
 
@@ -107,6 +110,8 @@ void MainWindow::onPushButtonClicked() {
       "Took " + QString::number(elapsedTime / 1000.0, 'f') + " seconds";
   manager->ShowNotification("Hashing Complete", message);
   ShowDupesInUI(*manager);
+  // re-enable the button
+  ui->RunReaperBTN->setEnabled(true);
 }
 
 // adds one file to qlistwidget

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -11,15 +11,17 @@ MainWindow::MainWindow(QWidget *parent)
   ui->checkBox->setChecked(true);
 
   // Tree Widget config:
-  ui->treeWidget->setColumnCount(
-      3);  // Single column for file names
+  ui->treeWidget->setColumnCount(3);  // Single column for file names
   // Make columns resizable
-  ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::Interactive);  // Filename
-  ui->treeWidget->header()->setSectionResizeMode(1, QHeaderView::Interactive);  // File Path
-  ui->treeWidget->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);  // Date Modified
+  ui->treeWidget->header()->setSectionResizeMode(
+      0, QHeaderView::Interactive);  // Filename
+  ui->treeWidget->header()->setSectionResizeMode(
+      1, QHeaderView::Interactive);  // File Path
+  ui->treeWidget->header()->setSectionResizeMode(
+      2, QHeaderView::ResizeToContents);  // Date Modified
   ui->treeWidget->header()->setMaximumSectionSize(300);
   ui->treeWidget->setHeaderLabels(
-      {"Filename","File Path", "Date Modified"});  // tree columns
+      {"Filename", "File Path", "Date Modified"});  // tree columns
   ui->treeWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   ui->treeWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   ui->treeWidget->header()->setSectionResizeMode(
@@ -78,7 +80,6 @@ void MainWindow::onPushButtonClicked() {
   // disable the button before reaping
   ui->RunReaperBTN->setEnabled(false);
 
-
   QStringList filePaths = manager->ListFiles(path);
 
   // Set up the progress bar
@@ -134,10 +135,12 @@ void MainWindow::ShowDupesInUI(const FileManager &f) {
   for (auto it = f.Dupes.begin(); it != f.Dupes.end(); ++it) {
     // Make a parent item for the list tree widget
     QTreeWidgetItem *parentHashItem = new QTreeWidgetItem(ui->treeWidget);
+    parentHashItem->setText(0, it->second.front().getFileName());
     parentHashItem->setText(
-        0, it->second.front().getFileName());
-    parentHashItem->setText(
-        1, QString::fromStdString(it->second.front().getFilePath().string()));  // Next column value to go under FilePath
+        1, QString::fromStdString(
+               it->second.front()
+                   .getFilePath()
+                   .string()));  // Next column value to go under FilePath
     parentHashItem->setText(2, it->second.front().getDate().toString());
     parentHashItem->setCheckState(0, Qt::Unchecked);  // Default unchecked
     // add the parent item to tree
@@ -149,17 +152,19 @@ void MainWindow::ShowDupesInUI(const FileManager &f) {
       // make a a child for the parent hash item
       QTreeWidgetItem *childItem = new QTreeWidgetItem(parentHashItem);
       childItem->setText(0, a.getFileName());  // set the filename
-      childItem->setText(
-          1, out); // sets the filepath column
-      childItem->setText(2,a.getDate().toString());
+      childItem->setText(1, out);              // sets the filepath column
+      childItem->setText(2, a.getDate().toString());
       childItem->setCheckState(0, Qt::Unchecked);
     }
   }
-  ui->treeWidget->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);  // Filename
-  ui->treeWidget->header()->setSectionResizeMode(1, QHeaderView::Interactive);  // File Path
-  ui->treeWidget->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);  // Date Modified
-  ui->treeWidget->setColumnWidth(1,200);
-  ui->treeWidget->setColumnWidth(2,150);
+  ui->treeWidget->header()->setSectionResizeMode(
+      0, QHeaderView::ResizeToContents);  // Filename
+  ui->treeWidget->header()->setSectionResizeMode(
+      1, QHeaderView::Interactive);  // File Path
+  ui->treeWidget->header()->setSectionResizeMode(
+      2, QHeaderView::ResizeToContents);  // Date Modified
+  ui->treeWidget->setColumnWidth(1, 200);
+  ui->treeWidget->setColumnWidth(2, 150);
 }
 
 // Function to manage parent-child checkbox behavior

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -39,7 +39,7 @@ MainWindow::MainWindow(QWidget *parent)
     // this links the button on the UI to the event function
     // "RunReaperBTN" is the name of the variable on the ui
     connect(ui->RunReaperBTN, &QPushButton::clicked, this,
-            &MainWindow::onPushButtonClicked);
+            &MainWindow::onReaperButtonClicked);
     // Connect signal to handle parent-child checkbox logic
     connect(ui->treeWidget, &QTreeWidget::itemChanged, this,
             &MainWindow::onTreeItemChanged);
@@ -68,7 +68,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
     }
 }
 
-void MainWindow::onPushButtonClicked() {
+void MainWindow::onReaperButtonClicked() {
     qDebug() << "Button clicked!";
     // clear the tree widget
     ui->treeWidget->clear();
@@ -105,7 +105,7 @@ void MainWindow::onPushButtonClicked() {
         FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                     fs::file_size(fPath));
         // Push and sort FileInfo class into FileManager class
-        manager->addFileToList(file);  // passes in fileinfo
+        manager->addFileToTypeSizeMap(file);  // passes in fileinfo
         // std::cout << *manager;  // DEBUG *************
 
         if (i % 50 == 0 || i == filePaths.size() - 1) {  // Update every 50 files
@@ -278,7 +278,7 @@ list<pair<QString, QString>> MainWindow::getCheckedItems() {
 
 /* PythonAutoTestHelper() : runs the entire program. This
  * function is used solely for testing the run time of the
- * program. It is a slightly modified copy of OnPushButtonClicked()
+ * program. It is a slightly modified copy of OnReaperButtonClicked()
  *
  * Input: A directory path to be run time tested
  * output: Run time in milliseconds
@@ -296,7 +296,7 @@ qint64 MainWindow::PythonAutoTestHelper(QString InputPath) {
         fs::path fPath = filePaths[i].toStdString();
         FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                   fs::file_size(fPath));
-        manager->addFileToList(file);
+        manager->addFileToTypeSizeMap(file);
     }
 
     return timer.elapsed();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -389,13 +389,11 @@ void MainWindow::showDeleteConfirmation(
   }
 }
 
-void MainWindow::on_HowUseBTN_clicked()
-{
-    if(!tutorial){
-        tutorial = new Tutorial(this);
-    }
-    tutorial->show();
-    tutorial->raise();  // Bring to front
-    tutorial->activateWindow(); // Give focus
+void MainWindow::on_HowUseBTN_clicked() {
+  if (!tutorial) {
+    tutorial = new Tutorial(this);
+  }
+  tutorial->show();
+  tutorial->raise();           // Bring to front
+  tutorial->activateWindow();  // Give focus
 }
-

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,130 +4,130 @@
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::MainWindow), manager(new FileManager()) {
-  ui->setupUi(this);
-  ui->progressBar->setValue(0);
-  this->setWindowTitle("Replica Reaper");
-  manager->setMainWindow(this);
-  // sets the background state
-  this->backgroundCheck = false;
+    ui->setupUi(this);
+    ui->progressBar->setValue(0);
+    this->setWindowTitle("Replica Reaper");
+    manager->setMainWindow(this);
+    // sets the background state
+    this->backgroundCheck = false;
 
-  // Tree Widget config:
-  ui->treeWidget->setColumnCount(3);  // Single column for file names
-  // Make columns resizable
-  ui->treeWidget->header()->setSectionResizeMode(
-      0, QHeaderView::Interactive);  // Filename
-  ui->treeWidget->header()->setSectionResizeMode(
-      1, QHeaderView::Interactive);  // File Path
-  ui->treeWidget->header()->setSectionResizeMode(
-      2, QHeaderView::ResizeToContents);  // Date Modified
-  ui->treeWidget->header()->setMaximumSectionSize(300);
-  ui->treeWidget->setHeaderLabels(
-      {"Filename", "File Path", "Date Modified"});  // tree columns
-  ui->treeWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  ui->treeWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-  ui->treeWidget->header()->setSectionResizeMode(
-      0, QHeaderView::ResizeToContents);  // File path length fits conted
-  ui->treeWidget->header()->setSectionResizeMode(
-      1, QHeaderView::ResizeToContents);  // Date Modified fits content
-  // ui->treeWidget->setColumnWidth(0, 1000);
-  // ui->treeWidget->setMinimumWidth(1000);
-  // set specifation for the list tree
-  // ui->treeWidget->setColumnHidden(1,true);
-  // ui->treeWidget->setColumnWidth(2, 2); // Setting the second column to
+    // Tree Widget config:
+    ui->treeWidget->setColumnCount(3);  // Single column for file names
+    // Make columns resizable
+    ui->treeWidget->header()->setSectionResizeMode(
+        0, QHeaderView::Interactive);  // Filename
+    ui->treeWidget->header()->setSectionResizeMode(
+        1, QHeaderView::Interactive);  // File Path
+    ui->treeWidget->header()->setSectionResizeMode(
+        2, QHeaderView::ResizeToContents);  // Date Modified
+    ui->treeWidget->header()->setMaximumSectionSize(300);
+    ui->treeWidget->setHeaderLabels(
+        {"Filename", "File Path", "Date Modified"});  // tree columns
+    ui->treeWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    ui->treeWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    ui->treeWidget->header()->setSectionResizeMode(
+        0, QHeaderView::ResizeToContents);  // File path length fits conted
+    ui->treeWidget->header()->setSectionResizeMode(
+        1, QHeaderView::ResizeToContents);  // Date Modified fits content
+    // ui->treeWidget->setColumnWidth(0, 1000);
+    // ui->treeWidget->setMinimumWidth(1000);
+    // set specifation for the list tree
+    // ui->treeWidget->setColumnHidden(1,true);
+    // ui->treeWidget->setColumnWidth(2, 2); // Setting the second column to
 
-  // Button Connections:
-  // this links the button on the UI to the event function
-  // "RunReaperBTN" is the name of the variable on the ui
-  connect(ui->RunReaperBTN, &QPushButton::clicked, this,
-          &MainWindow::onPushButtonClicked);
-  // Connect signal to handle parent-child checkbox logic
-  connect(ui->treeWidget, &QTreeWidget::itemChanged, this,
-          &MainWindow::onTreeItemChanged);
-  // Connect the "DelSelBTN" to the onDelSelBTN_clicked function
-  connect(ui->DelSelBTN, &QPushButton::clicked, this,
-          &MainWindow::onDelSelBTN_clicked);
-  // Connect the "DelAllBTN" to the onDelAllBTN_clicked function
-  connect(ui->DelAllBTN, &QPushButton::clicked, this,
-          &MainWindow::onDelAllBTN_clicked);
+    // Button Connections:
+    // this links the button on the UI to the event function
+    // "RunReaperBTN" is the name of the variable on the ui
+    connect(ui->RunReaperBTN, &QPushButton::clicked, this,
+            &MainWindow::onPushButtonClicked);
+    // Connect signal to handle parent-child checkbox logic
+    connect(ui->treeWidget, &QTreeWidget::itemChanged, this,
+            &MainWindow::onTreeItemChanged);
+    // Connect the "DelSelBTN" to the onDelSelBTN_clicked function
+    connect(ui->DelSelBTN, &QPushButton::clicked, this,
+            &MainWindow::onDelSelBTN_clicked);
+    // Connect the "DelAllBTN" to the onDelAllBTN_clicked function
+    connect(ui->DelAllBTN, &QPushButton::clicked, this,
+            &MainWindow::onDelAllBTN_clicked);
 }
 
 MainWindow::~MainWindow() {
-  delete ui;
-  delete manager;
+    delete ui;
+    delete manager;
 }
 
 // Overloaded function that automatically gets called when user closes UI
 void MainWindow::closeEvent(QCloseEvent *event) {
-  // if the "Run in Background" button is checked,
-  if (this->backgroundCheck) {
-    // If checked, just close the window (keeps running in bacnground)
-    event->accept();  // Accept the event, which will close the window
-  } else {
-    qApp->quit();  // Close the full application
-    event->accept();
-  }
+    // if the "Run in Background" button is checked,
+    if (this->backgroundCheck) {
+        // If checked, just close the window (keeps running in bacnground)
+        event->accept();  // Accept the event, which will close the window
+    } else {
+        qApp->quit();  // Close the full application
+        event->accept();
+    }
 }
 
 void MainWindow::onPushButtonClicked() {
-  qDebug() << "Button clicked!";
-  // clear the tree widget
-  ui->treeWidget->clear();
+    qDebug() << "Button clicked!";
+    // clear the tree widget
+    ui->treeWidget->clear();
 
-  QString path = manager->PromptDirectory(this);
-  if (path == QString()) {
-    qDebug("Please select a directory");
-    return;
-  }
-  // disable the button before reaping
-  ui->RunReaperBTN->setEnabled(false);
-  // set the status on the status bar
-  ui->statusbar->showMessage("Scanning Files...");
+    QString path = manager->PromptDirectory(this);
+    if (path == QString()) {
+        qDebug("Please select a directory");
+        return;
+    }
+    // disable the button before reaping
+    ui->RunReaperBTN->setEnabled(false);
+    // set the status on the status bar
+    ui->statusbar->showMessage("Scanning Files...");
 
-  QStringList filePaths = manager->ListFiles(path);
+    QStringList filePaths = manager->ListFiles(path);
 
-  // Set up the progress bar
-  ui->progressBar->setValue(0);                   // sets it to 0
-  ui->progressBar->setMinimum(0);                 // Min value
-  ui->progressBar->setMaximum(filePaths.size());  // # of files to hash
+    // Set up the progress bar
+    ui->progressBar->setValue(0);                   // sets it to 0
+    ui->progressBar->setMinimum(0);                 // Min value
+    ui->progressBar->setMaximum(filePaths.size());  // # of files to hash
 
-  // Set a timer for hashing all files
-  QElapsedTimer timer;
-  timer.start();
-  qDebug() << "Total amount files to cover: " << filePaths.size();
-  // Show the total amount in the status bar
-  ui->statusbar->showMessage("Found " + QString::number(filePaths.size()) +
+    // Set a timer for hashing all files
+    QElapsedTimer timer;
+    timer.start();
+    qDebug() << "Total amount files to cover: " << filePaths.size();
+    // Show the total amount in the status bar
+    ui->statusbar->showMessage("Found " + QString::number(filePaths.size()) +
                              " files");
-  // Loop through each file and hash it (prints to console for now)
+    // Loop through each file and hash it (prints to console for now)
 
-  for (int i = 0; i < filePaths.size(); ++i) {
-    // setup for FileInfo class
-    fs::path fPath = filePaths[i].toStdString();
-    FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
-                  fs::file_size(fPath));
-    // Push and sort FileInfo class into FileManager class
-    manager->addFileToList(file);  // passes in fileinfo
+    for (int i = 0; i < filePaths.size(); ++i) {
+        // setup for FileInfo class
+        fs::path fPath = filePaths[i].toStdString();
+        FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
+                    fs::file_size(fPath));
+        // Push and sort FileInfo class into FileManager class
+        manager->addFileToList(file);  // passes in fileinfo
+        // std::cout << *manager;  // DEBUG *************
+
+        if (i % 50 == 0 || i == filePaths.size() - 1) {  // Update every 50 files
+            ui->progressBar->setValue(i + 1);              // Update progress bar
+            // Process events to keep UI responsive (for progress bar)
+            QCoreApplication::processEvents();
+        }
+        // qDebug() << "File No: " << i;
+    }
+
     // std::cout << *manager;  // DEBUG *************
 
-    if (i % 50 == 0 || i == filePaths.size() - 1) {  // Update every 50 files
-      ui->progressBar->setValue(i + 1);              // Update progress bar
-      // Process events to keep UI responsive (for progress bar)
-      QCoreApplication::processEvents();
-    }
-    // qDebug() << "File No: " << i;
-  }
-
-  // std::cout << *manager;  // DEBUG *************
-
-  // returns elapsed time in milliseconds ( /1000 for seconds)
-  auto elapsedTime = timer.elapsed();
-  QString message =
-      "Took " + QString::number(elapsedTime / 1000.0, 'f') + " seconds";
-  manager->ShowNotification("Hashing Complete", message);
-  ShowDupesInUI(*manager);
-  // re-enable the button
-  ui->RunReaperBTN->setEnabled(true);
-  // clear the filemanager maps
-  manager->ClearData();
+    // returns elapsed time in milliseconds ( /1000 for seconds)
+    auto elapsedTime = timer.elapsed();
+    QString message =
+        "Took " + QString::number(elapsedTime / 1000.0, 'f') + " seconds";
+    manager->ShowNotification("Hashing Complete", message);
+    ShowDupesInUI(*manager);
+    // re-enable the button
+    ui->RunReaperBTN->setEnabled(true);
+    // clear the filemanager maps
+    manager->ClearData();
 }
 
 // adds one file to qlistwidget
@@ -137,143 +137,143 @@ void MainWindow::onPushButtonClicked() {
 // Does not currently locate items adjacently
 // NEED TO REFACTOR SO IT TAKES A FILEINFO
 void MainWindow::ShowDupesInUI(const FileManager &f) {
-  QString out;
-  for (auto it = f.Dupes.begin(); it != f.Dupes.end(); ++it) {
-    // Make a parent item for the list tree widget
-    QTreeWidgetItem *parentHashItem = new QTreeWidgetItem(ui->treeWidget);
-    parentHashItem->setText(0, it->second.front().getFileName());
-    parentHashItem->setText(
-        1, QString::fromStdString(
-               it->second.front()
-                   .getFilePath()
-                   .string()));  // Next column value to go under FilePath
-    parentHashItem->setText(2, it->second.front().getDate().toString());
-    parentHashItem->setCheckState(0, Qt::Unchecked);  // Default unchecked
-    // add the parent item to tree
-    ui->treeWidget->addTopLevelItem(parentHashItem);
+    QString out;
+    for (auto it = f.Dupes.begin(); it != f.Dupes.end(); ++it) {
+        // Make a parent item for the list tree widget
+        QTreeWidgetItem *parentHashItem = new QTreeWidgetItem(ui->treeWidget);
+        parentHashItem->setText(0, it->second.front().getFileName());
+        parentHashItem->setText(
+            1, QString::fromStdString(
+                it->second.front()
+                    .getFilePath()
+                    .string()));  // Next column value to go under FilePath
+        parentHashItem->setText(2, it->second.front().getDate().toString());
+        parentHashItem->setCheckState(0, Qt::Unchecked);  // Default unchecked
+        // add the parent item to tree
+        ui->treeWidget->addTopLevelItem(parentHashItem);
 
-    for (auto &a : it->second) {
-      out = QString::fromStdString(a.getFilePath().string());
-      // Logic for adding to list Tree:
-      // make a a child for the parent hash item
-      QTreeWidgetItem *childItem = new QTreeWidgetItem(parentHashItem);
-      childItem->setText(0, a.getFileName());  // set the filename
-      childItem->setText(1, out);              // sets the filepath column
-      childItem->setText(2, a.getDate().toString());
-      childItem->setCheckState(0, Qt::Unchecked);
+        for (auto &a : it->second) {
+            out = QString::fromStdString(a.getFilePath().string());
+            // Logic for adding to list Tree:
+            // make a a child for the parent hash item
+            QTreeWidgetItem *childItem = new QTreeWidgetItem(parentHashItem);
+            childItem->setText(0, a.getFileName());  // set the filename
+            childItem->setText(1, out);              // sets the filepath column
+            childItem->setText(2, a.getDate().toString());
+            childItem->setCheckState(0, Qt::Unchecked);
+        }
     }
-  }
-  ui->treeWidget->header()->setSectionResizeMode(
-      0, QHeaderView::ResizeToContents);  // Filename
-  ui->treeWidget->header()->setSectionResizeMode(
-      1, QHeaderView::Interactive);  // File Path
-  ui->treeWidget->header()->setSectionResizeMode(
-      2, QHeaderView::ResizeToContents);  // Date Modified
-  ui->treeWidget->setColumnWidth(1, 200);
-  ui->treeWidget->setColumnWidth(2, 150);
+    ui->treeWidget->header()->setSectionResizeMode(
+        0, QHeaderView::ResizeToContents);  // Filename
+    ui->treeWidget->header()->setSectionResizeMode(
+        1, QHeaderView::Interactive);  // File Path
+    ui->treeWidget->header()->setSectionResizeMode(
+        2, QHeaderView::ResizeToContents);  // Date Modified
+    ui->treeWidget->setColumnWidth(1, 200);
+    ui->treeWidget->setColumnWidth(2, 150);
 }
 
 // Function to manage parent-child checkbox behavior
 void MainWindow::onTreeItemChanged(QTreeWidgetItem *item) {
-  if (!item) return;
-  // Temporarily disconnect the signal to avoid recursion
-  // (because changing child checkstates in this function triggers it again)
-  disconnect(ui->treeWidget, &QTreeWidget::itemChanged, this,
-             &MainWindow::onTreeItemChanged);
+    if (!item) return;
+    // Temporarily disconnect the signal to avoid recursion
+    // (because changing child checkstates in this function triggers it again)
+    disconnect(ui->treeWidget, &QTreeWidget::itemChanged, this,
+                &MainWindow::onTreeItemChanged);
 
-  // If a parent item check (group header) is toggled,
-  if (item->parent() == nullptr) {
-    // Get the check status of the parent
-    Qt::CheckState newState = item->checkState(0);
-    // set all the childs states to match the parents
-    for (int i = 0; i < item->childCount(); ++i) {
-      item->child(i)->setCheckState(0, newState);
-    }
-  } else {  // If a child item is toggled
-    QTreeWidgetItem *parent = item->parent();
-    bool allChecked = true, anyChecked = false;
-    // compare all the child elements to see if some, all, or none are checked
-    for (int i = 0; i < parent->childCount(); ++i) {
-      Qt::CheckState state = parent->child(i)->checkState(0);
-      if (state == Qt::Checked) anyChecked = true;
-      if (state != Qt::Checked) allChecked = false;
-    }
+    // If a parent item check (group header) is toggled,
+    if (item->parent() == nullptr) {
+        // Get the check status of the parent
+        Qt::CheckState newState = item->checkState(0);
+        // set all the childs states to match the parents
+        for (int i = 0; i < item->childCount(); ++i) {
+            item->child(i)->setCheckState(0, newState);
+        }
+    } else {  // If a child item is toggled
+        QTreeWidgetItem *parent = item->parent();
+        bool allChecked = true, anyChecked = false;
+        // compare all the child elements to see if some, all, or none are checked
+        for (int i = 0; i < parent->childCount(); ++i) {
+            Qt::CheckState state = parent->child(i)->checkState(0);
+            if (state == Qt::Checked) anyChecked = true;
+            if (state != Qt::Checked) allChecked = false;
+        }
 
-    // Update parent state based on children
-    if (allChecked) {
-      parent->setCheckState(0, Qt::Checked);
-    } else if (anyChecked) {
-      parent->setCheckState(0, Qt::PartiallyChecked);
-    } else {  // none are checked
-      parent->setCheckState(0, Qt::Unchecked);
+        // Update parent state based on children
+        if (allChecked) {
+            parent->setCheckState(0, Qt::Checked);
+        } else if (anyChecked) {
+            parent->setCheckState(0, Qt::PartiallyChecked);
+        } else {  // none are checked
+            parent->setCheckState(0, Qt::Unchecked);
+        }
     }
-  }
-  // Reconnect the signal after the change is done
-  connect(ui->treeWidget, &QTreeWidget::itemChanged, this,
-          &MainWindow::onTreeItemChanged);
+    // Reconnect the signal after the change is done
+    connect(ui->treeWidget, &QTreeWidget::itemChanged, this,
+            &MainWindow::onTreeItemChanged);
 }
 
 void MainWindow::onDelSelBTN_clicked() {
-  // prints selected to console for now
-  // printCheckedItems();
-  auto files = getCheckedItems();
-  // dont show the dialoge if no files are selected
-  if (files.empty()) {
-    QMessageBox::information(this, "No Selection",
+    // prints selected to console for now
+    // printCheckedItems();
+    auto files = getCheckedItems();
+    // dont show the dialoge if no files are selected
+    if (files.empty()) {
+        QMessageBox::information(this, "No Selection",
                              "Please select at least one file to delete.");
-    return;
-  }
-  showDeleteConfirmation(files);
+        return;
+    }
+    showDeleteConfirmation(files);
 }
 void MainWindow::onDelAllBTN_clicked() {
-  // currently selects all buttons
+    // currently selects all buttons
 
-  // Iterate through all top-level parent items
-  for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i) {
-    QTreeWidgetItem *parentItem = ui->treeWidget->topLevelItem(i);
+    // Iterate through all top-level parent items
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i) {
+        QTreeWidgetItem *parentItem = ui->treeWidget->topLevelItem(i);
 
-    // Set the parent item to checked
-    parentItem->setCheckState(0, Qt::Checked);
-    // Child items should automatically check due to onTreeItemChanged()
-  }
+        // Set the parent item to checked
+        parentItem->setCheckState(0, Qt::Checked);
+        // Child items should automatically check due to onTreeItemChanged()
+    }
 }
 list<pair<QString, QString>> MainWindow::getCheckedItems() {
-  // pairs filename to filepath
-  list<pair<QString, QString>> files;
-  // iterate though the parent widgets
-  for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i) {
-    QTreeWidgetItem *parentItem = ui->treeWidget->topLevelItem(i);
+    // pairs filename to filepath
+    list<pair<QString, QString>> files;
+    // iterate though the parent widgets
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); ++i) {
+        QTreeWidgetItem *parentItem = ui->treeWidget->topLevelItem(i);
 
-    // Skip if the parent is unchecked (so no childs are checked)
-    if (parentItem->checkState(0) == Qt::Unchecked) {
-      continue;
+        // Skip if the parent is unchecked (so no childs are checked)
+        if (parentItem->checkState(0) == Qt::Unchecked) {
+            continue;
+        }
+
+        // Check the state of the parent item
+        if (parentItem->checkState(0) == Qt::Checked) {
+            qDebug() << "Checked Parent Group:" << parentItem->text(0);
+        } else if (parentItem->checkState(0) == Qt::PartiallyChecked) {
+            qDebug() << "Partially Checked Parent Group:" << parentItem->text(0);
+        }
+
+        // iterate through child items of the checked parent
+        for (int j = 0; j < parentItem->childCount(); ++j) {
+            QTreeWidgetItem *childItem = parentItem->child(j);
+
+            // Skip if the child is unchecked (for partially checked cases)
+            if (childItem->checkState(0) == Qt::Unchecked) {
+                continue;
+            } else {  // child is checked
+                qDebug() << "Checked Item:" << childItem->text(0);
+                auto filename = childItem->text(0);
+                auto filepath = childItem->text(1);
+                // add pairs to files
+                std::pair<QString, QString> pair(filename, filepath);
+                files.push_back(pair);
+            }
+        }
     }
-
-    // Check the state of the parent item
-    if (parentItem->checkState(0) == Qt::Checked) {
-      qDebug() << "Checked Parent Group:" << parentItem->text(0);
-    } else if (parentItem->checkState(0) == Qt::PartiallyChecked) {
-      qDebug() << "Partially Checked Parent Group:" << parentItem->text(0);
-    }
-
-    // iterate through child items of the checked parent
-    for (int j = 0; j < parentItem->childCount(); ++j) {
-      QTreeWidgetItem *childItem = parentItem->child(j);
-
-      // Skip if the child is unchecked (for partially checked cases)
-      if (childItem->checkState(0) == Qt::Unchecked) {
-        continue;
-      } else {  // child is checked
-        qDebug() << "Checked Item:" << childItem->text(0);
-        auto filename = childItem->text(0);
-        auto filepath = childItem->text(1);
-        // add pairs to files
-        std::pair<QString, QString> pair(filename, filepath);
-        files.push_back(pair);
-      }
-    }
-  }
-  return files;
+    return files;
 }
 
 /* PythonAutoTestHelper() : runs the entire program. This
@@ -284,22 +284,22 @@ list<pair<QString, QString>> MainWindow::getCheckedItems() {
  * output: Run time in milliseconds
  */
 qint64 MainWindow::PythonAutoTestHelper(QString InputPath) {
-  qDebug() << "Button clicked!";
+    qDebug() << "Button clicked!";
 
-  QString path = InputPath;
-  QStringList filePaths = manager->ListFiles(path);
+    QString path = InputPath;
+    QStringList filePaths = manager->ListFiles(path);
 
-  QElapsedTimer timer;
-  timer.start();
-  qDebug() << "Total amount files to cover: " << filePaths.size();
-  for (int i = 0; i < filePaths.size(); ++i) {
-    fs::path fPath = filePaths[i].toStdString();
-    FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
+    QElapsedTimer timer;
+    timer.start();
+    qDebug() << "Total amount files to cover: " << filePaths.size();
+    for (int i = 0; i < filePaths.size(); ++i) {
+        fs::path fPath = filePaths[i].toStdString();
+        FileInfo file(fPath, QString::fromStdString(fPath.extension().string()),
                   fs::file_size(fPath));
-    manager->addFileToList(file);
-  }
+        manager->addFileToList(file);
+    }
 
-  return timer.elapsed();
+    return timer.elapsed();
 }
 /* getDirectorySize() : Helper function for
  * finding the size of a directory
@@ -308,92 +308,92 @@ qint64 MainWindow::PythonAutoTestHelper(QString InputPath) {
  * output: size of file in bytes
  */
 qint64 MainWindow::getDirectorySize(const QString &dirPath) {
-  qint64 totalSize = 0;
-  QDirIterator it(dirPath, QDir::Files | QDir::Hidden | QDir::NoSymLinks,
-                  QDirIterator::Subdirectories);
+    qint64 totalSize = 0;
+    QDirIterator it(dirPath, QDir::Files | QDir::Hidden | QDir::NoSymLinks,
+                    QDirIterator::Subdirectories);
 
-  while (it.hasNext()) {
-    it.next();
-    QFileInfo fileInfo(it.filePath());
-    totalSize += fileInfo.size();
-  }
+    while (it.hasNext()) {
+        it.next();
+        QFileInfo fileInfo(it.filePath());
+        totalSize += fileInfo.size();
+    }
 
-  return totalSize;
+    return totalSize;
 }
 
 void MainWindow::on_SettBTN_clicked() {
-  Settings *settings = new Settings(this);
-  settings->setState(this->backgroundCheck);
-  settings->setModal(true);
-  settings->exec();
+    Settings *settings = new Settings(this);
+    settings->setState(this->backgroundCheck);
+    settings->setModal(true);
+    settings->exec();
 }
 
 void MainWindow::setBackgroundState(bool state) {
-  this->backgroundCheck = state;
+    this->backgroundCheck = state;
 }
 
 void MainWindow::showDeleteConfirmation(
-    const list<pair<QString, QString>> &files) {
-  QDialog dialog(this);
-  dialog.setWindowTitle("Confirm Deletion");
-  dialog.setModal(true);
-  dialog.setMinimumSize(400, 300);
+        const list<pair<QString, QString>> &files) {
+    QDialog dialog(this);
+    dialog.setWindowTitle("Confirm Deletion");
+    dialog.setModal(true);
+    dialog.setMinimumSize(400, 300);
 
-  QVBoxLayout *layout = new QVBoxLayout(&dialog);
+    QVBoxLayout *layout = new QVBoxLayout(&dialog);
 
-  QLabel *label =
-      new QLabel("Are you sure you want to delete the following files?");
-  layout->addWidget(label);
+    QLabel *label =
+        new QLabel("Are you sure you want to delete the following files?");
+    layout->addWidget(label);
 
-  QListWidget *listWidget = new QListWidget();
-  // Only add the first element of each pair (filename)
-  for (const auto &filePair : files) {
-    listWidget->addItem(filePair.first);
-  }
-  layout->addWidget(listWidget);
+    QListWidget *listWidget = new QListWidget();
+    // Only add the first element of each pair (filename)
+    for (const auto &filePair : files) {
+        listWidget->addItem(filePair.first);
+    }
+    layout->addWidget(listWidget);
 
-  QDialogButtonBox *buttonBox =
-      new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No);
-  layout->addWidget(buttonBox);
+    QDialogButtonBox *buttonBox =
+        new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No);
+    layout->addWidget(buttonBox);
 
-  QObject::connect(buttonBox, &QDialogButtonBox::accepted, &dialog,
-                   &QDialog::accept);
-  QObject::connect(buttonBox, &QDialogButtonBox::rejected, &dialog,
+    QObject::connect(buttonBox, &QDialogButtonBox::accepted, &dialog,
+                    &QDialog::accept);
+    QObject::connect(buttonBox, &QDialogButtonBox::rejected, &dialog,
                    &QDialog::reject);
 
-  if (dialog.exec() == QDialog::Accepted) {
-    // temperary "success flag"
-    QMessageBox::information(this, "Success",
+    if (dialog.exec() == QDialog::Accepted) {
+        // temperary "success flag"
+        QMessageBox::information(this, "Success",
                              "Selected files deleted successfully.");
-    // Delete files
-    // Deleting File Logic:
-    /*
-    QStringList failedDeletions;
+        // Delete files
+        // Deleting File Logic:
+        /*
+        QStringList failedDeletions;
 
-    for (const auto& filePair : files) {
-        QString fullPath = filePair.second;
-        QFile file(fullPath);
-        if (!file.remove()) {
+        for (const auto& filePair : files) {
+            QString fullPath = filePair.second;
+            QFile file(fullPath);
+            if (!file.remove()) {
             failedDeletions.append(fullPath);
         }
     }
 
-    if (!failedDeletions.isEmpty()) {
-        QString errorMsg = "Failed to delete the following files:\n" +
-    failedDeletions.join("\n"); QMessageBox::warning(this, "Deletion Failed",
-    errorMsg); } else { QMessageBox::information(this, "Success", "Selected
-    files deleted successfully.");
+        if (!failedDeletions.isEmpty()) {
+            QString errorMsg = "Failed to delete the following files:\n" +
+        failedDeletions.join("\n"); QMessageBox::warning(this, "Deletion Failed",
+        errorMsg); } else { QMessageBox::information(this, "Success", "Selected
+        files deleted successfully.");
     }*/
-  } else {
-    // Canceled
-  }
+    } else {
+        // Canceled
+    }
 }
 
 void MainWindow::on_HowUseBTN_clicked() {
-  if (!tutorial) {
-    tutorial = new Tutorial(this);
-  }
-  tutorial->show();
-  tutorial->raise();           // Bring to front
-  tutorial->activateWindow();  // Give focus
+    if (!tutorial) {
+        tutorial = new Tutorial(this);
+    }
+    tutorial->show();
+    tutorial->raise();           // Bring to front
+    tutorial->activateWindow();  // Give focus
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -80,6 +80,8 @@ void MainWindow::onPushButtonClicked() {
   }
   // disable the button before reaping
   ui->RunReaperBTN->setEnabled(false);
+  // set the status on the status bar
+  ui->statusbar->showMessage("Scanning Files...");
 
   QStringList filePaths = manager->ListFiles(path);
 
@@ -92,6 +94,8 @@ void MainWindow::onPushButtonClicked() {
   QElapsedTimer timer;
   timer.start();
   qDebug() << "Total amount files to cover: " << filePaths.size();
+  // Show the total amount in the status bar
+  ui->statusbar->showMessage("Found " + QString::number(filePaths.size()) + " files");
   // Loop through each file and hash it (prints to console for now)
 
   for (int i = 0; i < filePaths.size(); ++i) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -388,3 +388,14 @@ void MainWindow::showDeleteConfirmation(
     // Canceled
   }
 }
+
+void MainWindow::on_HowUseBTN_clicked()
+{
+    if(!tutorial){
+        tutorial = new Tutorial(this);
+    }
+    tutorial->show();
+    tutorial->raise();  // Bring to front
+    tutorial->activateWindow(); // Give focus
+}
+

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -95,7 +95,8 @@ void MainWindow::onPushButtonClicked() {
   timer.start();
   qDebug() << "Total amount files to cover: " << filePaths.size();
   // Show the total amount in the status bar
-  ui->statusbar->showMessage("Found " + QString::number(filePaths.size()) + " files");
+  ui->statusbar->showMessage("Found " + QString::number(filePaths.size()) +
+                             " files");
   // Loop through each file and hash it (prints to console for now)
 
   for (int i = 0; i < filePaths.size(); ++i) {
@@ -304,15 +305,13 @@ qint64 MainWindow::getDirectorySize(const QString &dirPath) {
   return totalSize;
 }
 
-void MainWindow::on_SettBTN_clicked()
-{
-    Settings* settings = new Settings(this);
-    settings->setState(this->backgroundCheck);
-    settings->setModal(true);
-    settings->exec();
+void MainWindow::on_SettBTN_clicked() {
+  Settings *settings = new Settings(this);
+  settings->setState(this->backgroundCheck);
+  settings->setModal(true);
+  settings->exec();
 }
 
-void MainWindow::setBackgroundState(bool state){
-    this->backgroundCheck = state;
+void MainWindow::setBackgroundState(bool state) {
+  this->backgroundCheck = state;
 }
-

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -11,9 +11,12 @@
 #include <QTreeWidget>
 #include <QDialogButtonBox>
 #include <QMessageBox>
+#include <QStandardPaths>
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <vector>
+#include <fstream>
 #include "filemanager.hpp"
 #include "FileInfo.hpp"
 #include "settings.hpp"
@@ -33,7 +36,7 @@ class MainWindow : public QMainWindow {
 
  public:
     explicit MainWindow(QWidget *parent = nullptr);
-    void onPushButtonClicked();
+    void onReaperButtonClicked();
     void ShowDupesInUI(const FileManager &f);
     void showDeleteConfirmation(const list<pair<QString, QString>>& files);
     void onTreeItemChanged(QTreeWidgetItem *item);

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -10,12 +10,17 @@
 #include <QDateTime>
 #include <QApplication>
 #include <QTreeWidget>
+#include <QDialogButtonBox>
+#include <QMessageBox>
 #include <filesystem>
 #include <iostream>
 #include <string>
 #include "filemanager.hpp"
 #include "FileInfo.hpp"
 #include "settings.hpp"
+
+using std::list;
+using std::pair;
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -30,10 +35,11 @@ class MainWindow : public QMainWindow {
   explicit MainWindow(QWidget *parent = nullptr);
   void onPushButtonClicked();
   void ShowDupesInUI(const FileManager &f);
+  void showDeleteConfirmation(const list<pair<QString, QString>>& files);
   void onTreeItemChanged(QTreeWidgetItem *item);
   void onDelSelBTN_clicked();
   void onDelAllBTN_clicked();
-  void printCheckedItems();
+  list<pair<QString, QString>> getCheckedItems();
   void setBackgroundState(bool state);
   void closeEvent(QCloseEvent *event);
   qint64 PythonAutoTestHelper(QString InputPath);

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -18,6 +18,7 @@
 #include "filemanager.hpp"
 #include "FileInfo.hpp"
 #include "settings.hpp"
+#include "tutorial.hpp"
 
 using std::list;
 using std::pair;
@@ -48,10 +49,12 @@ class MainWindow : public QMainWindow {
 
  private slots:
   void on_SettBTN_clicked();
+  void on_HowUseBTN_clicked();
 
  private:
   Ui::MainWindow *ui;
   FileManager *manager;
+  Tutorial *tutorial = nullptr;
   bool backgroundCheck;
 };
 #endif /* MAINWINDOW_HPP */

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -1,5 +1,4 @@
 // Copyright 2025 Replica Reaper
-#pragma once
 #ifndef MAINWINDOW_HPP
 #define MAINWINDOW_HPP
 
@@ -30,31 +29,31 @@ class MainWindow;
 QT_END_NAMESPACE
 
 class MainWindow : public QMainWindow {
-  Q_OBJECT
+    Q_OBJECT
 
  public:
-  explicit MainWindow(QWidget *parent = nullptr);
-  void onPushButtonClicked();
-  void ShowDupesInUI(const FileManager &f);
-  void showDeleteConfirmation(const list<pair<QString, QString>>& files);
-  void onTreeItemChanged(QTreeWidgetItem *item);
-  void onDelSelBTN_clicked();
-  void onDelAllBTN_clicked();
-  list<pair<QString, QString>> getCheckedItems();
-  void setBackgroundState(bool state);
-  void closeEvent(QCloseEvent *event);
-  qint64 PythonAutoTestHelper(QString InputPath);
-  qint64 getDirectorySize(const QString &dirPath);
-  ~MainWindow();
+    explicit MainWindow(QWidget *parent = nullptr);
+    void onPushButtonClicked();
+    void ShowDupesInUI(const FileManager &f);
+    void showDeleteConfirmation(const list<pair<QString, QString>>& files);
+    void onTreeItemChanged(QTreeWidgetItem *item);
+    void onDelSelBTN_clicked();
+    void onDelAllBTN_clicked();
+    list<pair<QString, QString>> getCheckedItems();
+    void setBackgroundState(bool state);
+    void closeEvent(QCloseEvent *event);
+    qint64 PythonAutoTestHelper(QString InputPath);
+    qint64 getDirectorySize(const QString &dirPath);
+    ~MainWindow();
 
  private slots:
-  void on_SettBTN_clicked();
-  void on_HowUseBTN_clicked();
+    void on_SettBTN_clicked();
+    void on_HowUseBTN_clicked();
 
  private:
-  Ui::MainWindow *ui;
-  FileManager *manager;
-  Tutorial *tutorial = nullptr;
-  bool backgroundCheck;
+    Ui::MainWindow *ui;
+    FileManager *manager;
+    Tutorial *tutorial = nullptr;
+    bool backgroundCheck;
 };
 #endif /* MAINWINDOW_HPP */

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -15,6 +15,7 @@
 #include <string>
 #include "filemanager.hpp"
 #include "FileInfo.hpp"
+#include "settings.hpp"
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -33,13 +34,18 @@ class MainWindow : public QMainWindow {
     void onDelSelBTN_clicked();
     void onDelAllBTN_clicked();
     void printCheckedItems();
+    void setBackgroundState(bool state);
     void closeEvent(QCloseEvent *event);
     qint64 PythonAutoTestHelper(QString InputPath);
     qint64 getDirectorySize(const QString& dirPath);
     ~MainWindow();
 
- private:
+private slots:
+    void on_SettBTN_clicked();
+
+private:
     Ui::MainWindow *ui;
     FileManager *manager;
+    bool backgroundCheck;
 };
 #endif /* MAINWINDOW_HPP */

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -24,28 +24,28 @@ class MainWindow;
 QT_END_NAMESPACE
 
 class MainWindow : public QMainWindow {
-    Q_OBJECT
+  Q_OBJECT
 
  public:
-    explicit MainWindow(QWidget *parent = nullptr);
-    void onPushButtonClicked();
-    void ShowDupesInUI(const FileManager& f);
-    void onTreeItemChanged(QTreeWidgetItem *item);
-    void onDelSelBTN_clicked();
-    void onDelAllBTN_clicked();
-    void printCheckedItems();
-    void setBackgroundState(bool state);
-    void closeEvent(QCloseEvent *event);
-    qint64 PythonAutoTestHelper(QString InputPath);
-    qint64 getDirectorySize(const QString& dirPath);
-    ~MainWindow();
+  explicit MainWindow(QWidget *parent = nullptr);
+  void onPushButtonClicked();
+  void ShowDupesInUI(const FileManager &f);
+  void onTreeItemChanged(QTreeWidgetItem *item);
+  void onDelSelBTN_clicked();
+  void onDelAllBTN_clicked();
+  void printCheckedItems();
+  void setBackgroundState(bool state);
+  void closeEvent(QCloseEvent *event);
+  qint64 PythonAutoTestHelper(QString InputPath);
+  qint64 getDirectorySize(const QString &dirPath);
+  ~MainWindow();
 
-private slots:
-    void on_SettBTN_clicked();
+ private slots:
+  void on_SettBTN_clicked();
 
-private:
-    Ui::MainWindow *ui;
-    FileManager *manager;
-    bool backgroundCheck;
+ private:
+  Ui::MainWindow *ui;
+  FileManager *manager;
+  bool backgroundCheck;
 };
 #endif /* MAINWINDOW_HPP */

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>869</width>
+    <height>653</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,8 +20,8 @@
    <widget class="QLabel" name="label">
     <property name="geometry">
      <rect>
-      <x>0</x>
-      <y>0</y>
+      <x>10</x>
+      <y>-10</y>
       <width>121</width>
       <height>51</height>
      </rect>
@@ -33,7 +33,7 @@
    <widget class="QProgressBar" name="progressBar">
     <property name="geometry">
      <rect>
-      <x>140</x>
+      <x>210</x>
       <y>0</y>
       <width>321</width>
       <height>41</height>
@@ -43,102 +43,11 @@
      <number>24</number>
     </property>
    </widget>
-   <widget class="QPushButton" name="RunReaperBTN">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>50</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Run the Reaper</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="DelAllBTN">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>90</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Delete all dupes</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="DelSelBTN">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>130</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Delete selected dupes</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="SelDirBTN">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>170</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Select Directory for Analysis</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="HowUseBTN">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>250</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>How to use</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="SettBTN">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>290</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Settings</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="SelDirBTN_2">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>210</y>
-      <width>121</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Select File for Cross Ref.</string>
-    </property>
-   </widget>
    <widget class="QCheckBox" name="checkBox">
     <property name="geometry">
      <rect>
-      <x>480</x>
-      <y>10</y>
+      <x>680</x>
+      <y>0</y>
       <width>161</width>
       <height>26</height>
      </rect>
@@ -150,9 +59,9 @@
    <widget class="QTreeWidget" name="treeWidget">
     <property name="geometry">
      <rect>
-      <x>130</x>
-      <y>50</y>
-      <width>651</width>
+      <x>10</x>
+      <y>120</y>
+      <width>851</width>
       <height>491</height>
      </rect>
     </property>
@@ -162,13 +71,60 @@
      </property>
     </column>
    </widget>
+   <widget class="QWidget" name="horizontalLayoutWidget">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>40</y>
+      <width>865</width>
+      <height>80</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="RunReaperBTN">
+       <property name="text">
+        <string>Run the Reaper</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="DelAllBTN">
+       <property name="text">
+        <string>Delete all dupes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="DelSelBTN">
+       <property name="text">
+        <string>Delete selected dupes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="HowUseBTN">
+       <property name="text">
+        <string>How to use</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="SettBTN">
+       <property name="text">
+        <string>Settings</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>800</width>
+     <width>869</width>
      <height>25</height>
     </rect>
    </property>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -70,6 +70,12 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="RunReaperBTN">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>50</height>
+        </size>
+       </property>
        <property name="text">
         <string>Run the Reaper</string>
        </property>
@@ -77,6 +83,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="DelAllBTN">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>50</height>
+        </size>
+       </property>
        <property name="text">
         <string>Delete all dupes</string>
        </property>
@@ -84,6 +96,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="DelSelBTN">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>50</height>
+        </size>
+       </property>
        <property name="text">
         <string>Delete selected dupes</string>
        </property>
@@ -91,6 +109,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="HowUseBTN">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>50</height>
+        </size>
+       </property>
        <property name="text">
         <string>How to use</string>
        </property>
@@ -98,6 +122,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="SettBTN">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>50</height>
+        </size>
+       </property>
        <property name="text">
         <string>Settings</string>
        </property>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -43,19 +43,6 @@
      <number>24</number>
     </property>
    </widget>
-   <widget class="QCheckBox" name="checkBox">
-    <property name="geometry">
-     <rect>
-      <x>680</x>
-      <y>0</y>
-      <width>161</width>
-      <height>26</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Run in Background?</string>
-    </property>
-   </widget>
    <widget class="QTreeWidget" name="treeWidget">
     <property name="geometry">
      <rect>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -17,124 +17,106 @@
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>-10</y>
-      <width>121</width>
-      <height>51</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Replica Reaper</string>
-    </property>
-   </widget>
-   <widget class="QProgressBar" name="progressBar">
-    <property name="geometry">
-     <rect>
-      <x>210</x>
-      <y>0</y>
-      <width>321</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="value">
-     <number>24</number>
-    </property>
-   </widget>
-   <widget class="QTreeWidget" name="treeWidget">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>120</y>
-      <width>851</width>
-      <height>491</height>
-     </rect>
-    </property>
-    <column>
-     <property name="text">
-      <string notr="true">1</string>
-     </property>
-    </column>
-   </widget>
-   <widget class="QWidget" name="horizontalLayoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>40</y>
-      <width>865</width>
-      <height>80</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="RunReaperBTN">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>50</height>
-        </size>
-       </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Replica Reaper</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QProgressBar" name="progressBar">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="value">
+       <number>24</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="RunReaperBTN">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Run the Reaper</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="DelAllBTN">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Delete all dupes</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="DelSelBTN">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Delete selected dupes</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="HowUseBTN">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>How to use</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="SettBTN">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>50</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Settings</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item row="2" column="0" colspan="2">
+     <widget class="QTreeWidget" name="treeWidget">
+      <column>
        <property name="text">
-        <string>Run the Reaper</string>
+        <string notr="true">1</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="DelAllBTN">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>50</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Delete all dupes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="DelSelBTN">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>50</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Delete selected dupes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="HowUseBTN">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>50</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>How to use</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="SettBTN">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>50</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Settings</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
+      </column>
+     </widget>
+    </item>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,0 +1,46 @@
+#include "settings.hpp"
+#include "ui_settings.h"
+#include <QMessageBox>
+#include <qevent.h>
+
+Settings::Settings(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::Settings)
+{
+    ui->setupUi(this);
+}
+
+Settings::~Settings()
+{
+    delete ui;
+}
+
+
+void Settings::on_cancelBTN_clicked()
+{
+    this->hide();
+}
+
+void Settings::on_applyBTN_clicked()
+{
+    applySettings();
+    this->hide();
+}
+void Settings::closeEvent(QCloseEvent *event) {
+    // event->accept();
+}
+
+void Settings::setState(bool backgroundCheck) {
+    ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
+}
+// applies the changed settings in the mainwindow
+void Settings::applySettings(){
+    MainWindow *mainWindow = qobject_cast<MainWindow*>(parent());
+    if (mainWindow) {
+        // Update the parent window's state
+        mainWindow->setBackgroundState(ui->bgCheckBox->isChecked());
+    }
+}
+
+
+

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,46 +1,32 @@
+// Copyright 2025 Replica Reaper
+#include <QMessageBox>
 #include "settings.hpp"
 #include "ui_settings.h"
-#include <QMessageBox>
-#include <qevent.h>
 
-Settings::Settings(QWidget *parent)
-    : QDialog(parent)
-    , ui(new Ui::Settings)
-{
-    ui->setupUi(this);
+Settings::Settings(QWidget *parent) : QDialog(parent), ui(new Ui::Settings) {
+  ui->setupUi(this);
 }
 
-Settings::~Settings()
-{
-    delete ui;
-}
+Settings::~Settings() { delete ui; }
 
+void Settings::on_cancelBTN_clicked() { this->hide(); }
 
-void Settings::on_cancelBTN_clicked()
-{
-    this->hide();
-}
-
-void Settings::on_applyBTN_clicked()
-{
-    applySettings();
-    this->hide();
+void Settings::on_applyBTN_clicked() {
+  applySettings();
+  this->hide();
 }
 void Settings::closeEvent(QCloseEvent *event) {
-    // event->accept();
+  // event->accept();
 }
 
 void Settings::setState(bool backgroundCheck) {
-    ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
+  ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
 }
 // applies the changed settings in the mainwindow
-void Settings::applySettings(){
-    MainWindow *mainWindow = qobject_cast<MainWindow*>(parent());
-    if (mainWindow) {
-        // Update the parent window's state
-        mainWindow->setBackgroundState(ui->bgCheckBox->isChecked());
-    }
+void Settings::applySettings() {
+  MainWindow *mainWindow = qobject_cast<MainWindow *>(parent());
+  if (mainWindow) {
+    // Update the parent window's state
+    mainWindow->setBackgroundState(ui->bgCheckBox->isChecked());
+  }
 }
-
-
-

--- a/settings.cpp
+++ b/settings.cpp
@@ -12,21 +12,21 @@ Settings::~Settings() { delete ui; }
 void Settings::on_cancelBTN_clicked() { this->hide(); }
 
 void Settings::on_applyBTN_clicked() {
-  applySettings();
-  this->hide();
+    applySettings();
+    this->hide();
 }
 void Settings::closeEvent(QCloseEvent *event) {
-  // event->accept();
+    // event->accept();
 }
 
 void Settings::setState(bool backgroundCheck) {
-  ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
+    ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
 }
 // applies the changed settings in the mainwindow
 void Settings::applySettings() {
-  MainWindow *mainWindow = qobject_cast<MainWindow *>(parent());
-  if (mainWindow) {
-    // Update the parent window's state
-    mainWindow->setBackgroundState(ui->bgCheckBox->isChecked());
-  }
+    MainWindow *mainWindow = qobject_cast<MainWindow *>(parent());
+    if (mainWindow) {
+        // Update the parent window's state
+        mainWindow->setBackgroundState(ui->bgCheckBox->isChecked());
+    }
 }

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,5 +1,4 @@
 // Copyright 2025 Replica Reaper
-#include <QMessageBox>
 #include "settings.hpp"
 #include "ui_settings.h"
 

--- a/settings.hpp
+++ b/settings.hpp
@@ -1,32 +1,34 @@
+// Copyright 2025 Replica Reaper
 #ifndef SETTINGS_HPP
 #define SETTINGS_HPP
 
 #include <QDialog>
+#include <QEvent>
 #include "mainwindow.hpp"
+
 namespace Ui {
 class Settings;
 }
 
-class Settings : public QDialog
-{
-    Q_OBJECT
+class Settings : public QDialog {
+  Q_OBJECT
 
-public:
-    explicit Settings(QWidget *parent = nullptr);
-    void applySettings();
-    void setState(bool backgroundCheck);
-    void closeEvent(QCloseEvent *event);
+ public:
+  explicit Settings(QWidget *parent = nullptr);
+  void applySettings();
+  void setState(bool backgroundCheck);
+  void closeEvent(QCloseEvent *event);
 
-    ~Settings();
+  ~Settings();
 
-private slots:
+ private slots:
 
-    void on_cancelBTN_clicked();
+  void on_cancelBTN_clicked();
 
-    void on_applyBTN_clicked();
+  void on_applyBTN_clicked();
 
-private:
-    Ui::Settings *ui;
+ private:
+  Ui::Settings *ui;
 };
 
-#endif // SETTINGS_HPP
+#endif  // SETTINGS_HPP

--- a/settings.hpp
+++ b/settings.hpp
@@ -4,6 +4,7 @@
 
 #include <QDialog>
 #include <QEvent>
+#include <QMessageBox>
 #include "mainwindow.hpp"
 
 namespace Ui {

--- a/settings.hpp
+++ b/settings.hpp
@@ -7,28 +7,28 @@
 #include "mainwindow.hpp"
 
 namespace Ui {
-class Settings;
+    class Settings;
 }
 
 class Settings : public QDialog {
-  Q_OBJECT
+    Q_OBJECT
 
  public:
-  explicit Settings(QWidget *parent = nullptr);
-  void applySettings();
-  void setState(bool backgroundCheck);
-  void closeEvent(QCloseEvent *event);
+    explicit Settings(QWidget *parent = nullptr);
+    void applySettings();
+    void setState(bool backgroundCheck);
+    void closeEvent(QCloseEvent *event);
 
-  ~Settings();
+    ~Settings();
 
  private slots:
 
-  void on_cancelBTN_clicked();
+    void on_cancelBTN_clicked();
 
-  void on_applyBTN_clicked();
+    void on_applyBTN_clicked();
 
  private:
-  Ui::Settings *ui;
+    Ui::Settings *ui;
 };
 
 #endif  // SETTINGS_HPP

--- a/settings.hpp
+++ b/settings.hpp
@@ -1,0 +1,32 @@
+#ifndef SETTINGS_HPP
+#define SETTINGS_HPP
+
+#include <QDialog>
+#include "mainwindow.hpp"
+namespace Ui {
+class Settings;
+}
+
+class Settings : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit Settings(QWidget *parent = nullptr);
+    void applySettings();
+    void setState(bool backgroundCheck);
+    void closeEvent(QCloseEvent *event);
+
+    ~Settings();
+
+private slots:
+
+    void on_cancelBTN_clicked();
+
+    void on_applyBTN_clicked();
+
+private:
+    Ui::Settings *ui;
+};
+
+#endif // SETTINGS_HPP

--- a/settings.hpp
+++ b/settings.hpp
@@ -8,7 +8,7 @@
 #include "mainwindow.hpp"
 
 namespace Ui {
-    class Settings;
+class Settings;
 }
 
 class Settings : public QDialog {

--- a/settings.ui
+++ b/settings.ui
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Settings</class>
+ <widget class="QDialog" name="Settings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QWidget" name="horizontalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>80</x>
+     <y>250</y>
+     <width>231</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <widget class="QPushButton" name="cancelBTN">
+      <property name="text">
+       <string>Cancel</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="applyBTN">
+      <property name="text">
+       <string>Apply</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="formLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>79</x>
+     <y>50</y>
+     <width>191</width>
+     <height>181</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="formLayout_2">
+    <item row="0" column="0">
+     <widget class="QCheckBox" name="bgCheckBox">
+      <property name="text">
+       <string>Run in Background?</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/tutorial.cpp
+++ b/tutorial.cpp
@@ -3,46 +3,46 @@
 #include "ui_tutorial.h"
 
 Tutorial::Tutorial(QWidget *parent) : QDialog(parent), ui(new Ui::Tutorial) {
-  ui->setupUi(this);
-  this->setWindowTitle("Tutorial");
-  ui->textBrowser->setHtml(R"(
-    <h2>How to Use Replica Reaper</h2>
-    <p>1. Click <b>Run the Reaper</b> to scan for duplicate files.</p>
-    <p>2. Review duplicates in the list below.</p>
-    <p>3. Use <b>Delete selected</b> or <b>Delete all</b> to remove them.</p>
-    <p>Need help? Visit our <a href='https://github.com/chrislambert3/Replica-Reaper'>Github</a>.</p>
-)");
-  // allows for the link to open
-  ui->textBrowser->setOpenExternalLinks(true);
-  // Lambda to check if a path exists and has files within
-  auto pathExists = [](const QString &path) -> bool {
-    QDir dir(path);
-    return dir.exists() && !dir.isEmpty();
-  };
+    ui->setupUi(this);
+    this->setWindowTitle("Tutorial");
+    ui->textBrowser->setHtml(R"(
+        <h2>How to Use Replica Reaper</h2>
+        <p>1. Click <b>Run the Reaper</b> to scan for duplicate files.</p>
+        <p>2. Review duplicates in the list below.</p>
+        <p>3. Use <b>Delete selected</b> or <b>Delete all</b> to remove them.</p>
+        <p>Need help? Visit our <a href='https://github.com/chrislambert3/Replica-Reaper'>Github</a>.</p>
+    )");
+    // allows for the link to open
+    ui->textBrowser->setOpenExternalLinks(true);
+    // Lambda to check if a path exists and has files within
+    auto pathExists = [](const QString &path) -> bool {
+        QDir dir(path);
+        return dir.exists() && !dir.isEmpty();
+    };
 
-  // Collect the standard paths
-  QString downloads =
-      QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
-  QString documents =
-      QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-  QString desktop =
-      QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-  QString pictures =
-      QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+    // Collect the standard paths
+    QString downloads =
+        QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    QString documents =
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    QString desktop =
+        QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    QString pictures =
+        QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
 
-  // Disable buttons if the respective path doesn't exist
-  if (!downloads.isEmpty() && !pathExists(downloads)) {
-    ui->tryDownBTN->setEnabled(false);
-  }
-  if (!documents.isEmpty() && !pathExists(documents)) {
-    ui->tryDocBTN->setEnabled(false);
-  }
-  if (!pictures.isEmpty() && !pathExists(pictures)) {
-    ui->tryPicBTN->setEnabled(false);
-  }
-  if (!desktop.isEmpty() && !pathExists(desktop)) {
-    ui->tryDeskBTN->setEnabled(false);
-  }
+    // Disable buttons if the respective path doesn't exist
+    if (!downloads.isEmpty() && !pathExists(downloads)) {
+        ui->tryDownBTN->setEnabled(false);
+    }
+    if (!documents.isEmpty() && !pathExists(documents)) {
+        ui->tryDocBTN->setEnabled(false);
+    }
+    if (!pictures.isEmpty() && !pathExists(pictures)) {
+        ui->tryPicBTN->setEnabled(false);
+    }
+    if (!desktop.isEmpty() && !pathExists(desktop)) {
+        ui->tryDeskBTN->setEnabled(false);
+    }
 }
 
 Tutorial::~Tutorial() { delete ui; }

--- a/tutorial.cpp
+++ b/tutorial.cpp
@@ -2,49 +2,47 @@
 #include "tutorial.hpp"
 #include "ui_tutorial.h"
 
-Tutorial::Tutorial(QWidget *parent)
-    : QDialog(parent)
-    , ui(new Ui::Tutorial)
-{
-    ui->setupUi(this);
-    this->setWindowTitle("Tutorial");
-    ui->textBrowser->setHtml(R"(
+Tutorial::Tutorial(QWidget *parent) : QDialog(parent), ui(new Ui::Tutorial) {
+  ui->setupUi(this);
+  this->setWindowTitle("Tutorial");
+  ui->textBrowser->setHtml(R"(
     <h2>How to Use Replica Reaper</h2>
     <p>1. Click <b>Run the Reaper</b> to scan for duplicate files.</p>
     <p>2. Review duplicates in the list below.</p>
     <p>3. Use <b>Delete selected</b> or <b>Delete all</b> to remove them.</p>
     <p>Need help? Visit our <a href='https://github.com/chrislambert3/Replica-Reaper'>Github</a>.</p>
 )");
-    // allows for the link to open
-    ui->textBrowser->setOpenExternalLinks(true);
-    // Lambda to check if a path exists and has files within
-    auto pathExists = [](const QString &path) -> bool {
-        QDir dir(path);
-        return dir.exists() && !dir.isEmpty();
-    };
+  // allows for the link to open
+  ui->textBrowser->setOpenExternalLinks(true);
+  // Lambda to check if a path exists and has files within
+  auto pathExists = [](const QString &path) -> bool {
+    QDir dir(path);
+    return dir.exists() && !dir.isEmpty();
+  };
 
-    // Collect the standard paths
-    QString downloads = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
-    QString documents = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-    QString desktop = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-    QString pictures = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+  // Collect the standard paths
+  QString downloads =
+      QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+  QString documents =
+      QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+  QString desktop =
+      QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+  QString pictures =
+      QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
 
-    // Disable buttons if the respective path doesn't exist
-    if (!downloads.isEmpty() && !pathExists(downloads)) {
-        ui->tryDownBTN->setEnabled(false);
-    }
-    if (!documents.isEmpty() && !pathExists(documents)) {
-        ui->tryDocBTN->setEnabled(false);
-    }
-    if (!pictures.isEmpty() && !pathExists(pictures)) {
-        ui->tryPicBTN->setEnabled(false);
-    }
-    if (!desktop.isEmpty() && !pathExists(desktop)) {
-        ui->tryDeskBTN->setEnabled(false);
-    }
+  // Disable buttons if the respective path doesn't exist
+  if (!downloads.isEmpty() && !pathExists(downloads)) {
+    ui->tryDownBTN->setEnabled(false);
+  }
+  if (!documents.isEmpty() && !pathExists(documents)) {
+    ui->tryDocBTN->setEnabled(false);
+  }
+  if (!pictures.isEmpty() && !pathExists(pictures)) {
+    ui->tryPicBTN->setEnabled(false);
+  }
+  if (!desktop.isEmpty() && !pathExists(desktop)) {
+    ui->tryDeskBTN->setEnabled(false);
+  }
 }
 
-Tutorial::~Tutorial()
-{
-    delete ui;
-}
+Tutorial::~Tutorial() { delete ui; }

--- a/tutorial.cpp
+++ b/tutorial.cpp
@@ -1,0 +1,50 @@
+// Copyright 2025 Replica Reaper
+#include "tutorial.hpp"
+#include "ui_tutorial.h"
+
+Tutorial::Tutorial(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::Tutorial)
+{
+    ui->setupUi(this);
+    this->setWindowTitle("Tutorial");
+    ui->textBrowser->setHtml(R"(
+    <h2>How to Use Replica Reaper</h2>
+    <p>1. Click <b>Run the Reaper</b> to scan for duplicate files.</p>
+    <p>2. Review duplicates in the list below.</p>
+    <p>3. Use <b>Delete selected</b> or <b>Delete all</b> to remove them.</p>
+    <p>Need help? Visit our <a href='https://github.com/chrislambert3/Replica-Reaper'>Github</a>.</p>
+)");
+    // allows for the link to open
+    ui->textBrowser->setOpenExternalLinks(true);
+    // Lambda to check if a path exists and has files within
+    auto pathExists = [](const QString &path) -> bool {
+        QDir dir(path);
+        return dir.exists() && !dir.isEmpty();
+    };
+
+    // Collect the standard paths
+    QString downloads = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    QString documents = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    QString desktop = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    QString pictures = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+
+    // Disable buttons if the respective path doesn't exist
+    if (!downloads.isEmpty() && !pathExists(downloads)) {
+        ui->tryDownBTN->setEnabled(false);
+    }
+    if (!documents.isEmpty() && !pathExists(documents)) {
+        ui->tryDocBTN->setEnabled(false);
+    }
+    if (!pictures.isEmpty() && !pathExists(pictures)) {
+        ui->tryPicBTN->setEnabled(false);
+    }
+    if (!desktop.isEmpty() && !pathExists(desktop)) {
+        ui->tryDeskBTN->setEnabled(false);
+    }
+}
+
+Tutorial::~Tutorial()
+{
+    delete ui;
+}

--- a/tutorial.hpp
+++ b/tutorial.hpp
@@ -9,16 +9,15 @@ namespace Ui {
 class Tutorial;
 }
 
-class Tutorial : public QDialog
-{
-    Q_OBJECT
+class Tutorial : public QDialog {
+  Q_OBJECT
 
-public:
-    explicit Tutorial(QWidget *parent = nullptr);
-    ~Tutorial();
+ public:
+  explicit Tutorial(QWidget *parent = nullptr);
+  ~Tutorial();
 
-private:
-    Ui::Tutorial *ui;
+ private:
+  Ui::Tutorial *ui;
 };
 
-#endif // TUTORIAL_H
+#endif  // TUTORIAL_H

--- a/tutorial.hpp
+++ b/tutorial.hpp
@@ -6,18 +6,18 @@
 #include <QStandardPaths>
 #include <QDir>
 namespace Ui {
-class Tutorial;
+    class Tutorial;
 }
 
 class Tutorial : public QDialog {
-  Q_OBJECT
+    Q_OBJECT
 
  public:
-  explicit Tutorial(QWidget *parent = nullptr);
-  ~Tutorial();
+    explicit Tutorial(QWidget *parent = nullptr);
+    ~Tutorial();
 
  private:
-  Ui::Tutorial *ui;
+    Ui::Tutorial *ui;
 };
 
 #endif  // TUTORIAL_H

--- a/tutorial.hpp
+++ b/tutorial.hpp
@@ -6,7 +6,7 @@
 #include <QStandardPaths>
 #include <QDir>
 namespace Ui {
-    class Tutorial;
+class Tutorial;
 }
 
 class Tutorial : public QDialog {

--- a/tutorial.hpp
+++ b/tutorial.hpp
@@ -1,0 +1,24 @@
+// Copyright 2025 Replica Reaper
+#ifndef TUTORIAL_H
+#define TUTORIAL_H
+
+#include <QDialog>
+#include <QStandardPaths>
+#include <QDir>
+namespace Ui {
+class Tutorial;
+}
+
+class Tutorial : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit Tutorial(QWidget *parent = nullptr);
+    ~Tutorial();
+
+private:
+    Ui::Tutorial *ui;
+};
+
+#endif // TUTORIAL_H

--- a/tutorial.ui
+++ b/tutorial.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Tutorial</class>
+ <widget class="QDialog" name="Tutorial">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>572</width>
+    <height>437</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QTextBrowser" name="textBrowser">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>551</width>
+     <height>231</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>249</y>
+     <width>551</width>
+     <height>171</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QPushButton" name="tryDownBTN">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Try Downloads</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="tryDocBTN">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Try Documents</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="tryDeskBTN">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Try Desktop</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="tryPicBTN">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="text">
+       <string>Try Pictures</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR adds safeguards such as no recursive root directory iteration and disabling the "Run" button while reaping.
There is also a reset state that clears the file manager map members when the "Run" button is clicked to allow multiple scans in in one session.
Also some overall UI cleanup/placeholder fill
Added a settings page and duplicate deletion selection logic

