### PR TITLE
Settings and Tutorial Unit Tests

### DIFF
--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -66,7 +66,7 @@ class FileManagerTest : public QObject {
   void test_TutorialExternalLinksEnabled();
   void test_TutorialButtonsCreation();
 
-  //Settings class Tests:
+  // Settings class Tests:
   void test_SettingsComponentCreation();
   void test_SettingsApplySettings();
   void test_SettingsCancelButtonClicked();

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -66,6 +66,16 @@ class FileManagerTest : public QObject {
   void test_TutorialExternalLinksEnabled();
   void test_TutorialButtonsCreation();
 
+  //Settings class Tests:
+  void test_SettingsComponentCreation();
+  void test_SettingsApplySettings();
+  void test_SettingsCancelButtonClicked();
+  void test_SettingsApplyButtonClicked();
+  void test_SettingsSetGetState();
+
+
+
+
   // cleanupTestCase() will be called after the last test function was executed.
   void cleanupTestCase();
 
@@ -503,6 +513,59 @@ void FileManagerTest::test_TutorialButtonsCreation() {
         // Check if the button was created
         QVERIFY(btn);
     }
+}
+
+void FileManagerTest::test_SettingsComponentCreation() {
+    // Verify all componest have been created
+    Settings dialog;
+    QCheckBox *backgroundCheckBox = dialog.findChild<QCheckBox*>("bgCheckBox");
+    QVERIFY(backgroundCheckBox);
+
+    QPushButton *applyButton = dialog.findChild<QPushButton*>("applyBTN");
+    QVERIFY(applyButton);
+
+    QPushButton *cancelButton = dialog.findChild<QPushButton*>("cancelBTN");
+    QVERIFY(cancelButton);
+}
+
+void FileManagerTest::test_SettingsSetGetState() {
+    Settings settings;
+    settings.setState(true);
+    QVERIFY(settings.getState() == true);
+
+    settings.setState(false);
+    QVERIFY(settings.getState() == false);
+}
+
+void FileManagerTest::test_SettingsApplySettings() {
+    MainWindow mainWindow;
+    Settings settings(&mainWindow);
+    settings.setState(true);
+    settings.applySettings();
+    QVERIFY(mainWindow.getBackgroundState() == true);
+
+    settings.setState(false);
+    settings.applySettings();
+    QVERIFY(mainWindow.getBackgroundState() == false);
+}
+
+void FileManagerTest::test_SettingsApplyButtonClicked() {
+    MainWindow mainWindow;
+    Settings settings(&mainWindow);
+    settings.setState(true);
+    settings.onApplyBTN_clicked();
+    QVERIFY(mainWindow.getBackgroundState() == true);
+    QVERIFY(settings.isHidden());
+}
+
+void FileManagerTest::test_SettingsCancelButtonClicked() {
+    // Verify that settings closes when cancel button is clicked
+    MainWindow window;
+    Settings settings(&window);
+    settings.show();
+    settings.onCancelBTN_clicked();
+    QVERIFY(settings.isHidden());
+    QVERIFY(window.getBackgroundState() == false);
 }
 
 // Cleans up after all test functions have executed

--- a/UnitTest/tst_filemanager.cpp
+++ b/UnitTest/tst_filemanager.cpp
@@ -5,6 +5,7 @@
 #include <QProgressBar>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
+#include <QTextBrowser>
 #include <filesystem>
 #include <string>
 #include "../filemanager.hpp"
@@ -59,6 +60,11 @@ class FileManagerTest : public QObject {
   void testFileInfoSetHash();
   void testFileInfoComparisonOperators();
   void testFileInfoDateCreated();
+
+  // Tutorial class Tests:
+  void test_TutorialTextBrowserContent();
+  void test_TutorialExternalLinksEnabled();
+  void test_TutorialButtonsCreation();
 
   // cleanupTestCase() will be called after the last test function was executed.
   void cleanupTestCase();
@@ -472,6 +478,31 @@ void FileManagerTest::testUncheckingAllChildSetsParentUncheck() {
 
   // Verify that the parent item is set to "Unchecked"
   QCOMPARE(parentItem->checkState(0), Qt::Unchecked);
+}
+
+void FileManagerTest::test_TutorialTextBrowserContent() {
+    Tutorial tutorial;
+    auto* textBrowser = tutorial.findChild<QTextBrowser *>("textBrowser");
+    QVERIFY(textBrowser);
+    QVERIFY(textBrowser->toHtml().contains("How to Use Replica Reaper"));
+    QVERIFY(textBrowser->toHtml().contains("Run the Reaper"));
+}
+
+void FileManagerTest::test_TutorialExternalLinksEnabled() {
+    Tutorial tutorial;
+    auto* textBrowser = tutorial.findChild<QTextBrowser*>("textBrowser");
+    QVERIFY(textBrowser);
+    QVERIFY(textBrowser->openExternalLinks());
+}
+
+void FileManagerTest::test_TutorialButtonsCreation() {
+    Tutorial tutorial;
+    QStringList buttonNames = {"tryDownBTN", "tryDocBTN", "tryPicBTN", "tryDeskBTN"};
+    for (const QString& btnName : buttonNames) {
+        QPushButton* btn = tutorial.findChild<QPushButton*>(btnName);
+        // Check if the button was created
+        QVERIFY(btn);
+    }
 }
 
 // Cleans up after all test functions have executed

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -8,8 +8,6 @@ MainWindow::MainWindow(QWidget *parent)
     ui->progressBar->setValue(0);
     this->setWindowTitle("Replica Reaper");
     manager->setMainWindow(this);
-    // sets the background state
-    this->backgroundCheck = false;
 
     // Tree Widget config:
     ui->treeWidget->setColumnCount(3);  // Single column for file names
@@ -59,7 +57,7 @@ MainWindow::~MainWindow() {
 // Overloaded function that automatically gets called when user closes UI
 void MainWindow::closeEvent(QCloseEvent *event) {
     // if the "Run in Background" button is checked,
-    if (this->backgroundCheck) {
+    if (this->settings.backgroundCheck) {
         // If checked, just close the window (keeps running in bacnground)
         event->accept();  // Accept the event, which will close the window
     } else {
@@ -323,13 +321,9 @@ qint64 MainWindow::getDirectorySize(const QString &dirPath) {
 
 void MainWindow::on_SettBTN_clicked() {
     Settings *settings = new Settings(this);
-    settings->setState(this->backgroundCheck);
+    settings->setState(this->settings.backgroundCheck);
     settings->setModal(true);
     settings->exec();
-}
-
-void MainWindow::setBackgroundState(bool state) {
-    this->backgroundCheck = state;
 }
 
 void MainWindow::showDeleteConfirmation(

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -49,6 +49,7 @@ MainWindow::MainWindow(QWidget *parent)
             &MainWindow::onDelAllBTN_clicked);
 }
 
+
 MainWindow::~MainWindow() {
     delete ui;
     delete manager;

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -47,8 +47,8 @@ class MainWindow : public QMainWindow {
     void onDelSelBTN_clicked();
     void onDelAllBTN_clicked();
     list<pair<QString, QString>> getCheckedItems();
-    void setBackgroundState(bool state){ settings.backgroundCheck = state;}
-    bool getBackgroundState(){ return settings.backgroundCheck;}
+    void setBackgroundState(bool state) { settings.backgroundCheck = state;}
+    bool getBackgroundState() { return settings.backgroundCheck;}
     void closeEvent(QCloseEvent *event);
     qint64 PythonAutoTestHelper(QString InputPath);
     qint64 getDirectorySize(const QString &dirPath);

--- a/mainwindow.hpp
+++ b/mainwindow.hpp
@@ -31,6 +31,10 @@ class MainWindow;
 }
 QT_END_NAMESPACE
 
+struct AppSettings {
+    bool backgroundCheck = false;
+};
+
 class MainWindow : public QMainWindow {
     Q_OBJECT
 
@@ -43,7 +47,8 @@ class MainWindow : public QMainWindow {
     void onDelSelBTN_clicked();
     void onDelAllBTN_clicked();
     list<pair<QString, QString>> getCheckedItems();
-    void setBackgroundState(bool state);
+    void setBackgroundState(bool state){ settings.backgroundCheck = state;}
+    bool getBackgroundState(){ return settings.backgroundCheck;}
     void closeEvent(QCloseEvent *event);
     qint64 PythonAutoTestHelper(QString InputPath);
     qint64 getDirectorySize(const QString &dirPath);
@@ -57,6 +62,6 @@ class MainWindow : public QMainWindow {
     Ui::MainWindow *ui;
     FileManager *manager;
     Tutorial *tutorial = nullptr;
-    bool backgroundCheck;
+    AppSettings settings;
 };
 #endif /* MAINWINDOW_HPP */

--- a/settings.cpp
+++ b/settings.cpp
@@ -27,7 +27,7 @@ void Settings::closeEvent(QCloseEvent *event) {
 void Settings::setState(bool backgroundCheck) {
     ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
 }
-bool Settings::getState(){
+bool Settings::getState() {
     return ui->bgCheckBox->isChecked();
 }
 // applies the changed settings in the mainwindow

--- a/settings.cpp
+++ b/settings.cpp
@@ -3,14 +3,20 @@
 #include "ui_settings.h"
 
 Settings::Settings(QWidget *parent) : QDialog(parent), ui(new Ui::Settings) {
-  ui->setupUi(this);
+    ui->setupUi(this);
+
+    // Connect apply and cancel buttons to functions
+    connect(ui->applyBTN, &QPushButton::clicked, this,
+            &Settings::onApplyBTN_clicked);
+    connect(ui->cancelBTN, &QPushButton::clicked, this,
+            &Settings::onCancelBTN_clicked);
 }
 
 Settings::~Settings() { delete ui; }
 
-void Settings::on_cancelBTN_clicked() { this->hide(); }
+void Settings::onCancelBTN_clicked() { this->hide(); }
 
-void Settings::on_applyBTN_clicked() {
+void Settings::onApplyBTN_clicked() {
     applySettings();
     this->hide();
 }
@@ -20,6 +26,9 @@ void Settings::closeEvent(QCloseEvent *event) {
 
 void Settings::setState(bool backgroundCheck) {
     ui->bgCheckBox->setCheckState(backgroundCheck ? Qt::Checked : Qt::Unchecked);
+}
+bool Settings::getState(){
+    return ui->bgCheckBox->isChecked();
 }
 // applies the changed settings in the mainwindow
 void Settings::applySettings() {

--- a/settings.hpp
+++ b/settings.hpp
@@ -6,6 +6,7 @@
 #include <QEvent>
 #include <QMessageBox>
 #include "mainwindow.hpp"
+#include "ui_settings.h"
 
 namespace Ui {
 class Settings;
@@ -18,15 +19,13 @@ class Settings : public QDialog {
     explicit Settings(QWidget *parent = nullptr);
     void applySettings();
     void setState(bool backgroundCheck);
+    bool getState();
+    void onCancelBTN_clicked();
+    void onApplyBTN_clicked();
     void closeEvent(QCloseEvent *event);
 
     ~Settings();
-
  private slots:
-
-    void on_cancelBTN_clicked();
-
-    void on_applyBTN_clicked();
 
  private:
     Ui::Settings *ui;


### PR DESCRIPTION
This pull requests adds unit test for the Tutorial and Settings classes. I changed the ```mainwindow.hpp``` to use a strut to hold for app settings suck as background check as well as. Also implemented getters and setters and made some function public so they can be accessed for unit tests